### PR TITLE
Show error if emitDecoratorMetadata isn't enabled

### DIFF
--- a/src/prop.ts
+++ b/src/prop.ts
@@ -141,6 +141,14 @@ const baseProp = (rawOptions, Type, target, key, isArray = false) => {
 
 export const prop = (options: PropOptionsWithValidate = {}) => (target: any, key: string) => {
   const Type = Reflect.getMetadata('design:type', target, key);
+  
+  if (!Type) {
+    throw new Error(
+      `There is no metadata for the "${key}" property. ` +
+      'Check if emitDecoratorMetadata is enable in tsconfig.json'
+    );
+  }
+  
   return baseProp(options, Type, target, key);
 };
 


### PR DESCRIPTION
Hi. Thank you for the awesome library.

I'm not very experienced with TS and I've spent a lot of time for that problem:
```
TypeError: Type is not a constructor
    at baseProp (typegoose/lib/prop.js:68:20)
```

So, I decided that it's very helpful to show this error if emitDecoratorMetadata isn't enabled.