### PR TITLE
Added the ability to pass schemaOptions object to getModelForClass()

### DIFF
--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -13,14 +13,16 @@ export type ModelType<T> = mongoose.Model<InstanceType<T>> & T;
 export class Typegoose {
   id: string;
 
-  getModelForClass<T>(t: T, existingMongoose?: mongoose.Mongoose) {
+  getModelForClass<T>(t: T, existingMongoose?: mongoose.Mongoose, schemaOptions?: mongoose.SchemaOptions) {
     const name = (this.constructor as any).name;
     if (!models[name]) {
       const Schema = existingMongoose ?
         existingMongoose.Schema.bind(existingMongoose) :
         mongoose.Schema.bind(mongoose);
 
-      const sch = new Schema(schema[name]);
+      const sch = schemaOptions ?
+        new Schema(schema[name], schemaOptions) :
+        new Schema(schema[name]);
 
       const staticMethods = methods.staticMethods[name];
       sch.statics = staticMethods;


### PR DESCRIPTION
First of all, great work here!

I believe one important missing feature is the ability to bypass the schemaOptions object to the underlying schema creation.

As an example: if you want mongoose to take care about **createdAt/updatedAt** in your collection/model, you can now do:

getModelForClass(yourClass, mongoose, **{timestamps: true}**);


This addition is a very easy one. I put it as a third parameter for getModelForClass() because I didn't want to break your tests (although I guess they are not working right now...). But maybe **it would be better idea to put it as second parameter before 'existingMongoose'**, since I believe it is more "natural" for Mongoose users who are used to write:

mongoose.model('foo', **fooSchema**, **fooSchemaOptions**);

// As a second parameter in your lib:
new Foo().getModelForClass(**Foo**, **fooSchemaOptions**);

If you need the existingMongoose feature, you could still do:

new Foo().getModelForClass(**Foo**, **fooSchemaOptions**, existingMongoose);

Feel free to choose! Hope you like this addition ;)
Cheers!