### PR TITLE
Added type definition to args

### DIFF
--- a/lib/prop.d.ts
+++ b/lib/prop.d.ts
@@ -1,4 +1,4 @@
-export declare type Func = (...args) => any;
+export declare type Func = (...args: any[]) => any;
 export declare type RequiredType = boolean | [boolean, string] | string | Func | [Func, string];
 export interface BasePropOptions {
     required?: RequiredType;


### PR DESCRIPTION
As I keep getting this error: ```Rest parameter 'args' implicitly has an 'any[]' type``` when using Visual Studio Code I added the type ```any[]``` to the parameter. 
That fixes that error for me.