### PR TITLE
Fixed the non assignable properties

### DIFF
--- a/src/prop.ts
+++ b/src/prop.ts
@@ -133,6 +133,7 @@ const baseProp = (rawOptions, Type, target, key, isArray = false) => {
       ...schema[name][key],
       ...options,
       type: Type,
+      writable: true,
     };
   }
 


### PR DESCRIPTION
No longer throws error: TypeError: Cannot assign to read only property ...
The problem is described in issue #41 (in my post)

This fix also makes _typegoose_ play nice with _ts-express-decorators_  (my motivation for solving the issue).
