### PR TITLE
Added support for Buffer, Mixed and Embedded schema types

### DIFF
--- a/src/prop.ts
+++ b/src/prop.ts
@@ -116,7 +116,7 @@ const baseProp = (rawOptions, Type, target, key, isArray = false) => {
     throw new NotNumberTypeError(key);
   }
 
-const instance = new Type();
+  const instance = new Type();
   const subSchema = schema[instance.constructor.name];
   if (!subSchema && !(isPrimitive(Type) || isMongoose(Type))) {
     throw new InvalidPropError(Type.name, key);

--- a/src/prop.ts
+++ b/src/prop.ts
@@ -2,7 +2,7 @@ import * as mongoose from 'mongoose';
 import * as _ from 'lodash';
 
 import { schema, virtuals } from './data';
-import { isPrimitive, initAsObject, initAsArray, isString, isNumber } from './utils';
+import { isPrimitive, isMongoose, initAsObject, initAsArray, isString, isNumber } from './utils';
 import { InvalidPropError, NotNumberTypeError, NotStringTypeError, NoMetadataError } from './errors';
 
 export type Func = (...args: any[]) => any;
@@ -116,14 +116,14 @@ const baseProp = (rawOptions, Type, target, key, isArray = false) => {
     throw new NotNumberTypeError(key);
   }
 
-  const instance = new Type();
+const instance = new Type();
   const subSchema = schema[instance.constructor.name];
-  if (!subSchema && !isPrimitive(Type)) {
+  if (!subSchema && !(isPrimitive(Type) || isMongoose(Type))) {
     throw new InvalidPropError(Type.name, key);
   }
 
   const options = _.omit(rawOptions, ['ref', 'items']);
-  if (isPrimitive(Type)) {
+  if (isPrimitive(Type) || isMongoose(Type)) {
     if (isArray) {
       schema[name][key][0] = {
         ...schema[name][key][0],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,9 @@ import * as mongoose from 'mongoose';
 
 import { schema, constructors } from './data';
 
-export const isPrimitive = (Type) => _.includes(['String', 'Number', 'Boolean', 'Date'], Type.name);
+export const isPrimitive = (Type) => _.includes(['String', 'Number', 'Boolean', 'Date', 'Buffer'], Type.name);
+
+export const isMongoose = (Type) => _.includes(['Mixed', 'Embedded'], Type.name);
 
 export const isNumber = (Type) => Type.name === 'Number';
 


### PR DESCRIPTION
Hi Akos

Added in some support for Buffer as a primitive type, and I've also created a separate list for the non primitive Schema.Types.

Perhaps move the lists out of the 'utils.ts' into a config object so that it can be defined on the typegoose singleton, with an optional closure that can be invoked at schema definition time, meaning that typegoose can be extended as needed.

Cheers
Stuart 