### PR TITLE
update @types/mongoose

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Akos Szokodi <akos@codingsans.com> (http://codingsans.com)",
   "license": "MIT",
   "dependencies": {
-    "@types/mongoose": "^4.7.15",
+    "@types/mongoose": "^4.7.28",
     "lodash": "^4.17.4",
     "mongoose": "^4.11.1",
     "reflect-metadata": "^0.1.8",


### PR DESCRIPTION
I'm unsure of why this seems to be an issue (I suspect it's either a change in `npm` with which I'm not yet familiar, or some sort of strange configuration issue). No matter how or where I try to install Typegoose, it installs version `4.7.15` of `@types/mongoose` as a dependency. (Given the `^4.7.15` setting in `package.json` I would expect it to install the latest patch, `4.7.28`.)

Without the patch, I get this error when connecting to Mongo:
```
error TS2345: Argument of type '{ useMongoClient: boolean; }' is not assignable to parameter of type '((err: MongoError) => void) | undefined'.
  Object literal may only specify known properties, and 'useMongoClient' does not exist in type '((err: MongoError) => void) | undefined'.

6 mongoose.connect('mongodb://localhost/zendesk', { useMongoClient: true })
```

Manually bumping the version works as expected, so I figured I'd send it upstream in case anyone else is having trouble.

I'm using npm `5.6.0` and node `8.9.3`. To reproduce, just:
```
mkdir testdir && cd testdir && npm install typegoose && grep '4.7.15' node_modules/@types/mongoose/package.json
```