### PR TITLE
Use native promises with mongoose

### DIFF
--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -2,6 +2,8 @@ import 'reflect-metadata';
 import * as mongoose from 'mongoose';
 import * as _ from 'lodash';
 
+(mongoose as any).Promise = global.Promise;
+
 import { schema, models, methods, virtuals, hooks, plugins, constructors } from './data';
 
 export * from './method';


### PR DESCRIPTION
Because I have two versions of Mongoose installed (one in my project, and another installed by Typegoose), I'm not able to modify `mongoose.Promise` on the module used by Typegoose, which means I'm seeing (and can't suppress):
```
 DeprecationWarning: Mongoose: mpromise (mongoose's default promise library) is deprecated, plug in your own promise library instead: http://mongoosejs.com/docs/promises.html
```

Now that native promises are in the LTS release, and Mongoose has deprecated `mpromise`, it would be great if this module also used native promises.