### PR TITLE
Property sparse in BasePropOptions added

### DIFF
--- a/src/prop.ts
+++ b/src/prop.ts
@@ -15,6 +15,7 @@ export interface BasePropOptions {
   default?: any;
   unique?: boolean;
   index?: boolean;
+  sparse?: boolean;
 }
 
 export interface PropOptions extends BasePropOptions {

--- a/src/test/models/user.ts
+++ b/src/test/models/user.ts
@@ -49,6 +49,9 @@ export class User extends Typegoose {
   @prop({ index: true, unique: true })
   uniqueId?: string;
 
+  @prop({ unique: true, sparse: true })
+  username?: string;
+
   @prop({ min: 10, max: 21 })
   age?: number;
 


### PR DESCRIPTION
Added property sparse in BasePropOptions. This is necessary in order to be able to save several objects that have a unique property, but which is not always available.

Sparse indexes only contain entries for documents that have the indexed field, even if the index field contains a null value (see [https://docs.mongodb.com/manual/core/index-sparse/](https://docs.mongodb.com/manual/core/index-sparse/))

If sparse is used, e. g. for username:

```
@prop ({ unique: true, sparse: true })
username?: string;
```

several objects with `username == null `can now be stored in the database without the error "MongoError: E11000 duplicate key error".