### PR TITLE
Add Decimal128 as primitive type.

### DIFF
--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -10,6 +10,8 @@ import { Genders } from './enums/genders';
 import { Role } from './enums/role';
 import { initDatabase, closeDatabase } from './utils/mongoConnect';
 import { getClassForDocument } from '../utils';
+import {Decimal128} from 'bson';
+import {fail} from 'assert';
 
 describe('Typegoose', () => {
   before(() => initDatabase());
@@ -19,12 +21,15 @@ describe('Typegoose', () => {
   it('should create a User with connections', async () => {
     const car = await Car.create({
       model: 'Tesla',
+      price: Decimal128.fromString('50123.25'),
     });
 
     const [trabant, zastava] = await Car.create([{
       model: 'Trabant',
+      price: Decimal128.fromString('28189.25'),
     }, {
       model: 'Zastava',
+      price: Decimal128.fromString('1234.25'),
     }]);
 
     const user = await User.create({
@@ -172,6 +177,7 @@ describe('getClassForDocument()', () => {
   it('should return correct class type for document', async () => {
     const car = await Car.create({
       model: 'Tesla',
+      price: Decimal128.fromString('50123.25'),
     });
     const carReflectedType = getClassForDocument(car);
     expect(carReflectedType).to.equals(CarType);
@@ -198,6 +204,7 @@ describe('getClassForDocument()', () => {
 
     const car = await Car.create({
       model: 'Tesla',
+      price: Decimal128.fromString('50123.25'),
     });
 
     await user.addCar(car);
@@ -237,5 +244,24 @@ describe('getClassForDocument()', () => {
     expect(person.moreAddresses.length).equals(2);
     expect(person.moreAddresses[0].street).equals('A Street 2');
     expect(person.moreAddresses[1].street).equals('A Street 3');
+  });
+
+  it('Should validate Decimal128', async () => {
+    try {
+      await Car.create({
+        model: 'Tesla',
+        price: 'NO DECIMAL',
+      });
+      fail('Validation must fail.');
+    } catch (e) {
+      expect(e).to.be.a.instanceof((mongoose.Error as any).ValidationError);
+    }
+    const car = await Car.create({
+      model: 'Tesla',
+      price: Decimal128.fromString('123.45'),
+    });
+    const foundCar = await Car.findById(car._id).exec();
+    expect(foundCar.price).to.be.a.instanceof(Decimal128);
+    expect(foundCar.price.toString()).to.eq('123.45');
   });
 });

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -10,8 +10,8 @@ import { Genders } from './enums/genders';
 import { Role } from './enums/role';
 import { initDatabase, closeDatabase } from './utils/mongoConnect';
 import { getClassForDocument } from '../utils';
-import {Decimal128} from 'bson';
-import {fail} from 'assert';
+import { Decimal128 } from 'bson';
+import { fail } from 'assert';
 
 describe('Typegoose', () => {
   before(() => initDatabase());

--- a/src/test/models/car.ts
+++ b/src/test/models/car.ts
@@ -1,7 +1,7 @@
 import * as mongoose from 'mongoose';
 
 import { Typegoose, prop, pre } from '../../typegoose';
-import {Decimal128} from 'bson';
+import { Decimal128 } from 'bson';
 
 @pre<Car>('save', function(next) {
   if (this.model === 'Trabant') {

--- a/src/test/models/car.ts
+++ b/src/test/models/car.ts
@@ -1,6 +1,7 @@
 import * as mongoose from 'mongoose';
 
 import { Typegoose, prop, pre } from '../../typegoose';
+import {Decimal128} from 'bson';
 
 @pre<Car>('save', function(next) {
   if (this.model === 'Trabant') {
@@ -14,6 +15,9 @@ export class Car extends Typegoose {
 
   @prop()
   isSedan?: boolean;
+
+  @prop({ required: true })
+  price: Decimal128;
 }
 
 export const model = new Car().getModelForClass(Car);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ import * as mongoose from 'mongoose';
 
 import { schema, constructors } from './data';
 
-export const isPrimitive = (Type) => _.includes(['String', 'Number', 'Boolean', 'Date'], Type.name);
+export const isPrimitive = (Type) => _.includes(['String', 'Number', 'Boolean', 'Date', 'Decimal128'], Type.name);
 
 export const isObject = (Type) => {
   let prototype = Type.prototype;

--- a/tslint.json
+++ b/tslint.json
@@ -29,6 +29,10 @@
         ],
         "no-unused-expression": [
             false
+        ],
+        "whitespace": [
+            true,
+            "check-module"
         ]
     },
     "rulesDirectory": []


### PR DESCRIPTION
fixes https://github.com/szokodiakos/typegoose/issues/114 by simply adding `Decimal128` as primitive type. Since it is perfectly supported by mongoose it seems to work.