### PR TITLE
Allow refType to be defined in @prop (issue #146)

### DIFF
--- a/src/prop.ts
+++ b/src/prop.ts
@@ -23,6 +23,7 @@ export interface BasePropOptions {
 
 export interface PropOptions extends BasePropOptions {
   ref?: any;
+  refType?: any;
 }
 
 export interface ValidateNumberOptions {
@@ -86,9 +87,13 @@ const baseProp = (rawOptions, Type, target, key, isArray = false) => {
 
   const ref = rawOptions.ref;
   if (ref) {
+    let refType = mongoose.Schema.Types.ObjectId;
+    if (rawOptions.refType) {
+      refType = rawOptions.refType;
+    }
     schema[name][key] = {
       ...schema[name][key],
-      type: mongoose.Schema.Types.ObjectId,
+      type: refType,
       ref: ref.name,
     };
     return;
@@ -96,9 +101,13 @@ const baseProp = (rawOptions, Type, target, key, isArray = false) => {
 
   const itemsRef = rawOptions.itemsRef;
   if (itemsRef) {
+    let refType = mongoose.Schema.Types.ObjectId;
+    if (rawOptions.refType) {
+      refType = rawOptions.refType;
+    }
     schema[name][key][0] = {
       ...schema[name][key][0],
-      type: mongoose.Schema.Types.ObjectId,
+      type: refType,
       ref: itemsRef.name,
     };
     return;

--- a/src/prop.ts
+++ b/src/prop.ts
@@ -195,7 +195,6 @@ const baseProp = (rawOptions, Type, target, key, isArray = false) => {
 
 export const prop = (options: PropOptionsWithValidate = {}) => (target: any, key: string) => {
   const Type = (Reflect as any).getMetadata('design:type', target, key);
-  const UnionType = (Reflect as any).getMetadata('design:type', target, key);
 
   if (!Type) {
     throw new NoMetadataError(key);


### PR DESCRIPTION
Improving on #148, I restricted the PropOptions.refType to be a union type of strings 'number', 'string', 'Buffer', and 'ObjectID'.

I previously was doing a union type of 

```js
mongoose.Schema.Types.Number | 
mongoose.Schema.Types.String | 
mongoose.Schema.Types.ObjectID | 
mongoose.Schema.Types.Buffer
```

however when mongoose.Schema.Types.Buffer is part of the union type then Typescript seemed to allow any of the mongoose.Schema.Types

Ref has also been modified a bit to cast the correct refType.

A prop example of how it can be used:

```ts
  @prop({ ref: Car, refType: 'number' })
  car?: Ref<Car, number>;
```
