### PR TITLE
Added initMethod decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,13 @@ incrementAge(this: InstanceType<User>) {
 }
 ```
 
+#### initMethod
+
+Post-init hooks are only called on documents that were actually fetched from the database. If you create a new instance of a document
+yourself, they don't run. Currently, the accepted solution in Mongoose is to add a method to the Schema and call Schema.queue() with it which will then run this method everytime a new instance is created (kind of a pre-init hook).
+
+The `initMethod` decorator marks a method to be such an automatically called initialize method. It works like `instanceMethod` in all other respects.
+
 ### Class decorators
 
 Mongoose allows the developer to add pre and post [hooks / middlewares](http://mongoosejs.com/docs/middleware.html) to the schema. With this it is possible to add document transformations and observations before or after validation, save and more.

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,8 +1,8 @@
-export const methods = { staticMethods: {}, instanceMethods: {} };
+export const methods = { staticMethods: {}, instanceMethods: {}, initMethods: {} };
 export const schema = {};
 export const models = {};
 export const virtuals = {};
 export const hooks = {};
 export const plugins = {};
 // tslint:disable-next-line:ban-types
-export const constructors: {[key: string]: Function} = {};
+export const constructors: { [key: string]: Function } = {};

--- a/src/method.ts
+++ b/src/method.ts
@@ -1,6 +1,6 @@
 import { methods } from './data';
 
-type MethodType = 'instanceMethods' | 'staticMethods';
+type MethodType = 'instanceMethods' | 'staticMethods' | 'initMethods';
 
 const baseMethod = (target: any, key: string, descriptor: TypedPropertyDescriptor<any>, methodType: MethodType) => {
   if (descriptor === undefined) {
@@ -8,7 +8,7 @@ const baseMethod = (target: any, key: string, descriptor: TypedPropertyDescripto
   }
 
   let name;
-  if (methodType === 'instanceMethods') {
+  if (methodType === 'instanceMethods' || methodType === 'initMethods') {
     name = target.constructor.name;
   }
   if (methodType === 'staticMethods') {
@@ -31,3 +31,6 @@ export const staticMethod = (target: any, key: string, descriptor: TypedProperty
 
 export const instanceMethod = (target: any, key: string, descriptor: TypedPropertyDescriptor<any>) =>
   baseMethod(target, key, descriptor, 'instanceMethods');
+
+export const initMethod = (target: any, key: string, descriptor: TypedPropertyDescriptor<any>) =>
+  baseMethod(target, key, descriptor, 'initMethods');

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -80,13 +80,13 @@ export class Typegoose {
     const initMethods = methods.initMethods[name];
     const instanceMethods = methods.instanceMethods[name];
     if (instanceMethods && initMethods) {
-      Object.getOwnPropertyNames(initMethods).forEach((name) => sch.queue(name, []));
+      Object.getOwnPropertyNames(initMethods).forEach((key) => sch.queue(key, []));
       sch.methods = Object.assign(instanceMethods, sch.methods || {});
       sch.methods = Object.assign(initMethods, sch.methods || {});
     } else if (instanceMethods) {
       sch.methods = Object.assign(instanceMethods, sch.methods || {});
     } else if (initMethods) {
-      Object.getOwnPropertyNames(initMethods).forEach((name) => sch.queue(name, []));
+      Object.getOwnPropertyNames(initMethods).forEach((key) => sch.queue(key, []));
       sch.methods = Object.assign(initMethods, sch.methods || {});
     } else {
       sch.methods = sch.methods || {};

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -80,13 +80,13 @@ export class Typegoose {
     const initMethods = methods.initMethods[name];
     const instanceMethods = methods.instanceMethods[name];
     if (instanceMethods && initMethods) {
-      Object.getOwnPropertyNames(initMethods).forEach(name => sch.queue(name, []));
+      Object.getOwnPropertyNames(initMethods).forEach((name) => sch.queue(name, []));
       sch.methods = Object.assign(instanceMethods, sch.methods || {});
       sch.methods = Object.assign(initMethods, sch.methods || {});
     } else if (instanceMethods) {
       sch.methods = Object.assign(instanceMethods, sch.methods || {});
     } else if (initMethods) {
-      Object.getOwnPropertyNames(initMethods).forEach(name => sch.queue(name, []));
+      Object.getOwnPropertyNames(initMethods).forEach((name) => sch.queue(name, []));
       sch.methods = Object.assign(initMethods, sch.methods || {});
     } else {
       sch.methods = sch.methods || {};

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -77,9 +77,17 @@ export class Typegoose {
       sch.statics = sch.statics || {};
     }
 
+    const initMethods = methods.initMethods[name];
     const instanceMethods = methods.instanceMethods[name];
-    if (instanceMethods) {
+    if (instanceMethods && initMethods) {
+      Object.getOwnPropertyNames(initMethods).forEach(name => sch.queue(name, []));
       sch.methods = Object.assign(instanceMethods, sch.methods || {});
+      sch.methods = Object.assign(initMethods, sch.methods || {});
+    } else if (instanceMethods) {
+      sch.methods = Object.assign(instanceMethods, sch.methods || {});
+    } else if (initMethods) {
+      Object.getOwnPropertyNames(initMethods).forEach(name => sch.queue(name, []));
+      sch.methods = Object.assign(initMethods, sch.methods || {});
     } else {
       sch.methods = sch.methods || {};
     }


### PR DESCRIPTION
This PR adds the initMethod decorator which will call the decorated method when an InstanceType is created. Post-Init hooks only work for documents actually fetched from the database. This works as the proposed workaround in this Mongoose issue:

https://github.com/Automattic/mongoose/issues/2363