### PR TITLE
Add missing string validation options

### DIFF
--- a/src/prop.ts
+++ b/src/prop.ts
@@ -31,9 +31,13 @@ export interface ValidateNumberOptions {
 }
 
 export interface ValidateStringOptions {
+  lowercase?: boolean;
+  uppercase?: boolean;
+  trim?: boolean;
+  match?: RegExp | [RegExp, string];
+  enum?: string[];
   minlength?: number | [number, string];
   maxlength?: number | [number, string];
-  match?: RegExp | [RegExp, string];
 }
 
 export type PropOptionsWithNumberValidate = PropOptions & ValidateNumberOptions;
@@ -41,7 +45,15 @@ export type PropOptionsWithStringValidate = PropOptions & ValidateStringOptions;
 export type PropOptionsWithValidate = PropOptionsWithNumberValidate | PropOptionsWithStringValidate;
 
 const isWithStringValidate = (options: PropOptionsWithStringValidate) =>
-  (options.minlength || options.maxlength || options.match);
+  (
+    options.lowercase
+    || options.uppercase
+    || options.trim
+    || options.match
+    || options.enum
+    || options.minlength
+    || options.maxlength
+  );
 
 const isWithNumberValidate = (options: PropOptionsWithNumberValidate) =>
   (options.min || options.max);
@@ -170,7 +182,7 @@ const baseProp = (rawOptions, Type, target, key, isArray = false) => {
   schema[name][key] = {
     ...schema[name][key],
     ...options,
-    type: new Schema({ ...subSchema }, supressSubschemaId ? { _id: false } : {}),
+    type: new Schema({...subSchema}, supressSubschemaId ? {_id: false} : {}),
   };
   return;
 };

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -5,6 +5,7 @@ import * as mongoose from 'mongoose';
 import { model as User, User as UserType } from './models/user';
 import { model as Car, Car as CarType } from './models/car';
 import { model as Person, PersistentModel } from './models/person';
+import { model as StringValidators } from './models/stringValidators';
 import { PersonNested, AddressNested, PersonNestedModel } from './models/nested-object';
 import { Genders } from './enums/genders';
 import { Role } from './enums/role';
@@ -168,6 +169,41 @@ describe('Typegoose', () => {
     expect(savedUser.previousJobs.length).to.be.above(0);
     _.map(savedUser.previousJobs, (prevJob) => {
       expect(prevJob.startedAt).to.be.ok;
+    });
+  });
+
+  describe('string validators', () => {
+    // TODO: Specify an identifier for the error messages, e. g. as a regex to the message content.
+    // Otherwise we could catch errors that have nothing to do with what is being tested.
+
+    it('should respect maxlength', () => {
+      expect(async () => {
+        await StringValidators.create({
+          maxlength: 'this is too long',
+        });
+      }).throws(mongoose.Error);
+    });
+
+    it('should trim', async () => {
+      const trimmed = await StringValidators.create({
+        trim: 'trim my end    ',
+      });
+      expect(trimmed.trimmed).equals('trim my end');
+    });
+
+    it('should uppercase', async () => {
+      const uppercased = await StringValidators.create({
+        uppercased: 'make me uppercase',
+      });
+      expect(uppercased.uppercased).equals('MAKE ME UPPERCASE');
+    });
+
+    it('should respect enum', async () => {
+      expect(async () => {
+        await StringValidators.create({
+          enum: 'i am not valid',
+        });
+      }).throws(mongoose.Error);
     });
   });
 });

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -186,7 +186,7 @@ describe('Typegoose', () => {
 
     it('should trim', async () => {
       const trimmed = await StringValidators.create({
-        trim: 'trim my end    ',
+        trimmed: 'trim my end    ',
       });
       expect(trimmed.trimmed).equals('trim my end');
     });

--- a/src/test/models/stringValidators.ts
+++ b/src/test/models/stringValidators.ts
@@ -1,0 +1,27 @@
+import * as mongoose from 'mongoose';
+
+import { Typegoose, prop } from '../../typegoose';
+
+export class StringValidators extends Typegoose {
+  @prop({
+    maxlength: 3,
+  })
+  maxLength: string;
+
+  @prop({
+    trim: true,
+  })
+  trimmed: string;
+
+  @prop({
+    uppercase: true,
+  })
+  uppercased: string;
+
+  @prop({
+    enum: ['one', 'two', 'three'],
+  })
+  enumed: string;
+}
+
+export const model = new StringValidators().getModelForClass(StringValidators);


### PR DESCRIPTION
The current types do not support all [string validation options](http://mongoosejs.com/docs/schematypes.html#schematypes).

Missing:
- lowercase
- uppercase
- trim
- enum

I hope I didn't miss anything, since it was very easy to add these to the `ValidateStringOptions` type.