### PR TITLE
Support for custom validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ email: string;
 
 // or
 
-@prop({ validate: (value) => { new Promise(res => { res(isEmail(value)) }) })
+@prop({ validate: (value) => { return new Promise(res => { res(isEmail(value)) }) })
 email: string;
 
 // or
@@ -272,6 +272,7 @@ email: string;
 email: string;
 
 // you can also use multiple validators in an array.
+
 @prop({ validate: 
     [
         { 

--- a/README.md
+++ b/README.md
@@ -244,6 +244,49 @@ age?: number;
 favouriteHexNumber: string;
 ```
 
+
+  - `validate` (custom validators): You can define your own validator function/regex using this. The function has to return a `boolean` or a Promise (async validation).
+
+```typescript
+// you have to get your own `isEmail` function, this is a placeholder
+
+@prop({ validate: (value) => isEmail(value)})
+email: string;
+
+// or
+
+@prop({ validate: (value) => { new Promise(res => { res(isEmail(value)) }) })
+email: string;
+
+// or
+
+@prop({ validate: { 
+    validator: val => isEmail(val), 
+    message: `{VALUE} is not a valid email`
+}})
+email: string;
+
+// or
+
+@prop({ validate: /\S+@\S+\.\S+/ })
+email: string;
+
+// you can also use multiple validators in an array.
+@prop({ validate: 
+    [
+        { 
+            validator: val => isEmail(val), 
+            message: `{VALUE} is not a valid email`
+        }, 
+        {
+            validator: val => isBlacklisted(val), 
+            message: `{VALUE} is blacklisted`
+        }
+    ]
+})
+email: string;
+```
+
 Mongoose gives developers the option to create [virtual properties](http://mongoosejs.com/docs/api.html#schema_Schema-virtual). This means that actual database read/write will not occur these are just 'calculated properties'. A virtual property can have a setter and a getter. TypeScript also has a similar feature which Typegoose uses for virtual property definitions (using the `prop` decorator).
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -251,12 +251,12 @@ favouriteHexNumber: string;
 // you have to get your own `isEmail` function, this is a placeholder
 
 @prop({ validate: (value) => isEmail(value)})
-email: string;
+email?: string;
 
 // or
 
 @prop({ validate: (value) => { return new Promise(res => { res(isEmail(value)) }) })
-email: string;
+email?: string;
 
 // or
 
@@ -264,12 +264,12 @@ email: string;
     validator: val => isEmail(val), 
     message: `{VALUE} is not a valid email`
 }})
-email: string;
+email?: string;
 
 // or
 
 @prop({ validate: /\S+@\S+\.\S+/ })
-email: string;
+email?: string;
 
 // you can also use multiple validators in an array.
 
@@ -285,7 +285,7 @@ email: string;
         }
     ]
 })
-email: string;
+email?: string;
 ```
 
 Mongoose gives developers the option to create [virtual properties](http://mongoosejs.com/docs/api.html#schema_Schema-virtual). This means that actual database read/write will not occur these are just 'calculated properties'. A virtual property can have a setter and a getter. TypeScript also has a similar feature which Typegoose uses for virtual property definitions (using the `prop` decorator).

--- a/src/prop.ts
+++ b/src/prop.ts
@@ -10,10 +10,17 @@ export type Func = (...args: any[]) => any;
 
 export type RequiredType = boolean | [boolean, string] | string | Func | [Func, string];
 
+export type ValidatorFunction = (value: any) => boolean | Promise<boolean>;
+export type Validator = ValidatorFunction | RegExp | {
+    validator: ValidatorFunction,
+    message?: string,
+};
+
 export interface BasePropOptions {
   required?: RequiredType;
   enum?: string[] | object;
   default?: any;
+  validate?: Validator | Validator[];
   unique?: boolean;
   index?: boolean;
   sparse?: boolean;

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -265,4 +265,15 @@ describe('getClassForDocument()', () => {
     expect(foundCar.price).to.be.a.instanceof(Decimal128);
     expect(foundCar.price.toString()).to.eq('123.45');
   });
+
+  it('Should validate email', async () => {
+    try {
+      await Person.create({
+          email: 'email',
+      });
+      fail('Validation must fail.');
+    } catch (e) {
+      expect(e).to.be.a.instanceof((mongoose.Error as any).ValidationError);
+    }
+  });
 });

--- a/src/test/models/person.ts
+++ b/src/test/models/person.ts
@@ -43,7 +43,7 @@ export abstract class PersistentModel extends tg.Typegoose {
 
 export class Person extends PersistentModel {
     // add new property
-    @tg.prop({ required: true })
+    @tg.prop({ required: true, validate: /^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$/ })
     email: string;
 
     // override instanceMethod


### PR DESCRIPTION
Adds support for custom validators. Sync/async functions or regex.

Example (added to README.md):
```typescript
// you have to get your own `isEmail` function, this is a placeholder

@prop({ validate: (value) => isEmail(value)})
email: string;

// or

@prop({ validate: (value) => { return new Promise(res => { res(isEmail(value)) }) })
email: string;

// or

@prop({ validate: { 
    validator: val => isEmail(val), 
    message: `{VALUE} is not a valid email`
}})
email: string;

// or

@prop({ validate: /\S+@\S+\.\S+/ })
email: string;

// you can also use multiple validators in an array.

@prop({ validate: 
    [
        { 
            validator: val => isEmail(val), 
            message: `{VALUE} is not a valid email`
        }, 
        {
            validator: val => isBlacklisted(val), 
            message: `{VALUE} is blacklisted`
        }
    ]
})
email: string;
```