### PR TITLE
add @index class decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,11 +439,16 @@ UserModel.findOrCreate({ ... }).then(findOrCreateResult => {
 
 #### index
 
-To declare compound indices or other advanced (eg. GeoJSON indices) `index` option of `@prop` decorator is not sufficient. For those cases use `@index`:
+The `@index` decorator can be used to define advanced index types and index options not available via the
+`index` option of the `@prop` property decorator, such as compound indices, GeoJSON index types,
+partial indices, expiring documents, etc. Any values supported by
+[MongoDB's createIndex()](https://docs.mongodb.com/manual/reference/method/db.collection.createIndex/#db.collection.createIndex)
+are also valid for `@index`. For more info refer to interface `IndexOptions`
 
-```typescript
+ ```typescript
 @index({ article: 1, user: 1 }, { unique: true })
-@index({ location: '2dsphere'})
+@index({ location: '2dsphere' })
+@index({ article: 1 }, { partialFilterExpression: { stars: { $gte: 4.5 } } })
 export class Location extends Typegoose {
   @prop()
   article: number;
@@ -458,8 +463,6 @@ export class Location extends Typegoose {
   location: [[Number]]
 }
 ```
-
-For more info about creating indices refer to [MongoDB documentation](https://docs.mongodb.com/manual/indexes/).
 
 ### Types
 

--- a/README.md
+++ b/README.md
@@ -437,6 +437,30 @@ UserModel.findOrCreate({ ... }).then(findOrCreateResult => {
 });
 ```
 
+#### index
+
+To declare compound indices or other advanced (eg. GeoJSON indices) `index` option of `@prop` decorator is not sufficient. For those cases use `@index`:
+
+```typescript
+@index({ article: 1, user: 1 }, { unique: true })
+@index({ location: '2dsphere'})
+export class Location extends Typegoose {
+  @prop()
+  article: number;
+
+  @prop()
+  user: number;
+
+  @prop()
+  stars: number;
+
+  @arrayProp({ items: Array })
+  location: [[Number]]
+}
+```
+
+For more info about creating indices refer to [MongoDB documentation](https://docs.mongodb.com/manual/indexes/).
+
 ### Types
 
 Some additional types were added to make Typegoose more user friendly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -149,11 +149,11 @@
       "dev": true
     },
     "async": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
-      "integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ=",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
-        "lodash": "^4.14.0"
+        "lodash": "^4.17.10"
       }
     },
     "asynckit": {
@@ -223,9 +223,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -430,7 +430,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -819,9 +818,9 @@
       }
     },
     "kareem": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.0.1.tgz",
-      "integrity": "sha512-SsR+TZe595qXYzbWS5KWHBt4mM5h1MA7HFXp3oZnPkunxjaymx0fKhB8cxl6/R7Qm8aFXnI6J7DnyxV/QUSKLA=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.2.1.tgz",
+      "integrity": "sha512-xpDFy8OxkFM+vK6pXy6JmH92ibeEFUuDWzas5M9L7MzVmHW3jzwAHxodCPV/BYkf4A31bVDLyonrMfp9RXb/oA=="
     },
     "kind-of": {
       "version": "3.2.2",
@@ -960,37 +959,49 @@
       }
     },
     "mongodb": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.0.1.tgz",
-      "integrity": "sha1-J47oAGJX7CJ5hZSmJZVGgl1t4bI=",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.4.tgz",
+      "integrity": "sha512-BGUxo4a/p5KtZpOn6+z6iZXTHfDxKDvibHQap9uMJqQouwoszvTIO/QbVZkaSX3Spny0jtTEeHc0FwfpGbtEzA==",
       "requires": {
-        "mongodb-core": "3.0.1"
+        "mongodb-core": "3.1.3",
+        "safe-buffer": "^5.1.2"
       }
     },
     "mongodb-core": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.0.1.tgz",
-      "integrity": "sha1-/23Dbulv9ZaVPYCmhA1nMbyS7+0=",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.3.tgz",
+      "integrity": "sha512-dISiV3zHGJTwZpg0xDhi9zCqFGMhA5kDPByHlcaEp09NSKfzHJ7XQbqVrL7qhki1U9PZHsmRfbFzco+6b1h2wA==",
       "requires": {
-        "bson": "~1.0.4",
-        "require_optional": "^1.0.1"
+        "bson": "^1.1.0",
+        "require_optional": "^1.0.1",
+        "safe-buffer": "^5.1.2",
+        "saslprep": "^1.0.0"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.0.tgz",
+          "integrity": "sha512-9Aeai9TacfNtWXOYarkFJRW2CWo+dRon+fuLZYJmvLV3+MiUp0bEI6IAZfXEIg7/Pl/7IWlLaDnhzTsD81etQA=="
+        }
       }
     },
     "mongoose": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.0.0.tgz",
-      "integrity": "sha512-ciHZSJsy37SpUXotPmhPR4uVXG6YEUDVAjPmYO3g5n7JCGnPeczH9ipwyCfDCORyu6vic2AKY0TMYW0WIuRdFA==",
+      "version": "5.2.13",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.2.13.tgz",
+      "integrity": "sha512-KF5pEQNNhqsNKaBkmlLsFh1u5CVe04SoQ5bSQ/7NHvUx+oVnQ6K7tQJaB1wu3To4qFXKJWE41k8OenqrBlluFw==",
       "requires": {
-        "async": "2.1.4",
-        "bson": "~1.0.4",
-        "kareem": "2.0.1",
+        "async": "2.6.1",
+        "bson": "~1.0.5",
+        "kareem": "2.2.1",
         "lodash.get": "4.4.2",
-        "mongodb": "3.0.1",
-        "mongoose-legacy-pluralize": "1.0.1",
-        "mpath": "0.3.0",
-        "mquery": "3.0.0-rc0",
+        "mongodb": "3.1.4",
+        "mongodb-core": "3.1.3",
+        "mongoose-legacy-pluralize": "1.0.2",
+        "mpath": "0.5.1",
+        "mquery": "3.2.0",
         "ms": "2.0.0",
         "regexp-clone": "0.0.1",
+        "safe-buffer": "5.1.2",
         "sliced": "1.0.1"
       }
     },
@@ -1001,39 +1012,25 @@
       "dev": true
     },
     "mongoose-legacy-pluralize": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.1.tgz",
-      "integrity": "sha512-X5/N3sNj1p+y7Bg1vouQdST1vkInEzNAwqVjfDpNrhnugih2p2rV7jLrrb71sbQUPMJPm0Hhe6rH5fQV1Ve4XQ=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
+      "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
     },
     "mpath": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.3.0.tgz",
-      "integrity": "sha1-elj3iem1/TyUUgY0FXlg8mvV70Q="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.5.1.tgz",
+      "integrity": "sha512-H8OVQ+QEz82sch4wbODFOz+3YQ61FYz/z3eJ5pIdbMEaUzDqA268Wd+Vt4Paw9TJfvDgVKaayC0gBzMIw2jhsg=="
     },
     "mquery": {
-      "version": "3.0.0-rc0",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.0.0-rc0.tgz",
-      "integrity": "sha512-tEAVSvlmd22irKJ8Q/tyI0LKRv8cV3aEkQ/EHW391ktGRWDDlfcpZyq6GYqu8yXGoz2JkC4aMJdNGca19wU1NQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.0.tgz",
+      "integrity": "sha512-qPJcdK/yqcbQiKoemAt62Y0BAc0fTEKo1IThodBD+O5meQRJT/2HSe5QpBNwaa4CjskoGrYWsEyjkqgiE0qjhg==",
       "requires": {
-        "bluebird": "3.5.0",
-        "debug": "2.6.9",
+        "bluebird": "3.5.1",
+        "debug": "3.1.0",
         "regexp-clone": "0.0.1",
-        "sliced": "0.0.5"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "sliced": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
-          "integrity": "sha1-XtwETKTrb3gW1Qui/GPiXY/kcH8="
-        }
+        "safe-buffer": "5.1.2",
+        "sliced": "1.0.1"
       }
     },
     "ms": {
@@ -1247,14 +1244,19 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "saslprep": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.1.tgz",
+      "integrity": "sha512-ntN6SbE3hRqd45PKKadRPgA+xHPWg5lPSj2JWJdJvjTwXDDfkPVtXWvP8jJojvnm+rAsZ2b299C5NwZqq818EA==",
+      "optional": true
     },
     "semver": {
       "version": "5.5.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,63 @@
 /**
+ * copy-paste from mongodb package (should be same as IndexOptions from 'mongodb')
+ */
+export interface IndexOptions {
+  /**
+   * Mongoose-specific syntactic sugar, uses ms to convert
+   * expires option into seconds for the expireAfterSeconds in the above link.
+   */
+  expires?: string;
+  /**
+   * Creates an unique index.
+   */
+  unique?: boolean;
+  /**
+   * Creates a sparse index.
+   */
+  sparse?: boolean;
+  /**
+   * Creates the index in the background, yielding whenever possible.
+   */
+  background?: boolean;
+  /**
+   * A unique index cannot be created on a key that has pre-existing duplicate values.
+   * If you would like to create the index anyway, keeping the first document the database indexes and
+   * deleting all subsequent documents that have duplicate value
+   */
+  dropDups?: boolean;
+  /**
+   * For geo spatial indexes set the lower bound for the co-ordinates.
+   */
+  min?: number;
+  /**
+   * For geo spatial indexes set the high bound for the co-ordinates.
+   */
+  max?: number;
+  /**
+   * Specify the format version of the indexes.
+   */
+  v?: number;
+  /**
+   * Allows you to expire data on indexes applied to a data (MongoDB 2.2 or higher)
+   */
+  expireAfterSeconds?: number;
+  /**
+   * Override the auto generated index name (useful if the resulting name is larger than 128 bytes)
+   */
+  name?: string;
+  /**
+   * Creates a partial index based on the given filter object (MongoDB 3.2 or higher)
+   */
+  partialFilterExpression?: any;
+  collation?: object;
+  default_language?: string;
+}
+
+/**
  * Defines an index (most likely compound) for this schema.
  * @param options Options to pass to MongoDB driver's createIndex() function
- * @param options.expires Mongoose-specific syntactic sugar, uses ms to convert
- *   expires option into seconds for the expireAfterSeconds in the above link.
  */
-export const index = (fields: any, options?: { expires?: string, [others: string]: any }) => {
+export const index = (fields: any, options?: IndexOptions) => {
   return (constructor) => {
     const indices = Reflect.getMetadata('typegoose:indices', constructor) || [];
     indices.push({ fields, options });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Defines an index (most likely compound) for this schema.
+ * @param options Options to pass to MongoDB driver's createIndex() function
+ * @param options.expires Mongoose-specific syntactic sugar, uses ms to convert
+ *   expires option into seconds for the expireAfterSeconds in the above link.
+ */
+export function index(fields: any, options?: { expires?: string, [others: string]: any }) {
+  return function (constructor: Function) {
+    const indices = Reflect.getMetadata('typegoose:indices', constructor) || [];
+    indices.push({ fields, options });
+    Reflect.defineMetadata('typegoose:indices', indices, constructor);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,10 @@
  * @param options.expires Mongoose-specific syntactic sugar, uses ms to convert
  *   expires option into seconds for the expireAfterSeconds in the above link.
  */
-export function index(fields: any, options?: { expires?: string, [others: string]: any }) {
-  return function (constructor: Function) {
+export const index = (fields: any, options?: { expires?: string, [others: string]: any }) => {
+  return (constructor) => {
     const indices = Reflect.getMetadata('typegoose:indices', constructor) || [];
     indices.push({ fields, options });
     Reflect.defineMetadata('typegoose:indices', indices, constructor);
-  }
-}
+  };
+};

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -5,6 +5,7 @@ import * as mongoose from 'mongoose';
 import { model as User, User as UserType } from './models/user';
 import { model as Car, Car as CarType } from './models/car';
 import { model as Person, PersistentModel } from './models/person';
+import { model as Rating } from './models/rating';
 import { PersonNested, AddressNested, PersonNestedModel } from './models/nested-object';
 import { Genders } from './enums/genders';
 import { Role } from './enums/role';
@@ -168,6 +169,19 @@ describe('Typegoose', () => {
     _.map(savedUser.previousJobs, (prevJob) => {
       expect(prevJob.startedAt).to.be.ok;
     });
+  });
+
+  it('should add compound index', async () => {
+    const user = await User.findOne();
+    const car = await Car.findOne();
+    
+    await Rating.create({ user: user._id, car: car._id, stars: 4 });
+    
+    // should fail, because user and car should be unique 
+    const created = await Rating.create({ user: user._id, car: car._id, stars: 5 })
+      .then(() => true).catch(e => false);
+
+    expect(created).to.be.false;
   });
 });
 

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -137,7 +137,7 @@ describe('Typegoose', () => {
       expect(foundUser.doc).to.have.property('firstName', 'Jane');
 
       try {
-        const cloneUser = await User.create({
+        await User.create({
           _id: mongoose.Types.ObjectId(),
           firstName: 'John',
           lastName: 'Doe',
@@ -146,7 +146,6 @@ describe('Typegoose', () => {
           uniqueId: 'john-doe-20',
         });
       } catch (err) {
-        expect(err).to.have.property('name', 'MongoError');
         expect(err).to.have.property('code', 11000);
       }
     }
@@ -174,12 +173,12 @@ describe('Typegoose', () => {
   it('should add compound index', async () => {
     const user = await User.findOne();
     const car = await Car.findOne();
-    
+
     await Rating.create({ user: user._id, car: car._id, stars: 4 });
-    
-    // should fail, because user and car should be unique 
+
+    // should fail, because user and car should be unique
     const created = await Rating.create({ user: user._id, car: car._id, stars: 5 })
-      .then(() => true).catch(e => false);
+      .then(() => true).catch(() => false);
 
     expect(created).to.be.false;
   });

--- a/src/test/models/rating.ts
+++ b/src/test/models/rating.ts
@@ -19,7 +19,7 @@ export class Rating extends Typegoose {
   stars: number;
 
   @arrayProp({ items: Array })
-  location: [[Number]]
+  location: [[number]];
 }
 
 export const model = new Rating().getModelForClass(Rating);

--- a/src/test/models/rating.ts
+++ b/src/test/models/rating.ts
@@ -1,0 +1,25 @@
+import * as mongoose from 'mongoose';
+
+import { index } from '../..';
+import { Ref, arrayProp } from '../../prop';
+import { prop, Typegoose } from '../../typegoose';
+import { Car } from './car';
+import { User } from './user';
+
+@index({ car: 1, user: 1 }, { unique: true })
+@index({ location: '2dsphere'})
+export class Rating extends Typegoose {
+  @prop({ ref: Car })
+  car: Ref<Car>;
+
+  @prop({ ref: User })
+  user: Ref<User>;
+
+  @prop()
+  stars: number;
+
+  @arrayProp({ items: Array })
+  location: [[Number]]
+}
+
+export const model = new Rating().getModelForClass(Rating);

--- a/src/test/utils/mongoConnect.ts
+++ b/src/test/utils/mongoConnect.ts
@@ -11,7 +11,14 @@ const connect = () =>
   );
 
 export const initDatabase = () =>
-  connect().then(() => mongoose.connection.db.dropDatabase());
+  connect()
+    .then(() => mongoose.connection.db.dropDatabase())
+    .then(() => Promise.all(
+      // recreate all indexes
+      Object.keys(mongoose.models).map(async modelName => {
+        await mongoose.models[modelName].createIndexes();
+      })
+    ));
 
 export const closeDatabase = () =>
   mongoose.connection.close();

--- a/src/test/utils/mongoConnect.ts
+++ b/src/test/utils/mongoConnect.ts
@@ -13,12 +13,10 @@ const connect = () =>
 export const initDatabase = () =>
   connect()
     .then(() => mongoose.connection.db.dropDatabase())
-    .then(() => Promise.all(
-      // recreate all indexes
-      Object.keys(mongoose.models).map(async modelName => {
-        await mongoose.models[modelName].createIndexes();
-      })
-    ));
+    // recreate all indices
+    .then(() => Promise.all(Object.keys(mongoose.models).map(async (modelName) => {
+      await mongoose.models[modelName].createIndexes();
+    })));
 
 export const closeDatabase = () =>
   mongoose.connection.close();

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -10,6 +10,7 @@ export * from './method';
 export * from './prop';
 export * from './hooks';
 export * from './plugin';
+export * from '.';
 export { getClassForDocument } from './utils';
 
 export type InstanceType<T> = T & mongoose.Document;
@@ -35,13 +36,13 @@ export class Typegoose {
     const name = this.constructor.name;
 
     // get schema of current model
-    let sch = this.buildSchema(name, schemaOptions);
+    let sch = this.buildSchema<T>(t, name, schemaOptions);
     // get parents class name
     let parentCtor = Object.getPrototypeOf(this.constructor.prototype).constructor;
     // iterate trough all parents
     while (parentCtor && parentCtor.name !== 'Typegoose' && parentCtor.name !== 'Object') {
       // extend schema
-      sch = this.buildSchema(parentCtor.name, schemaOptions, sch);
+      sch = this.buildSchema<T>(t, parentCtor.name, schemaOptions, sch);
       // next parent
       parentCtor = Object.getPrototypeOf(parentCtor.prototype).constructor;
     }
@@ -59,7 +60,7 @@ export class Typegoose {
     return models[name] as ModelType<this> & T;
   }
 
-  private buildSchema(name: string, schemaOptions, sch?: mongoose.Schema) {
+  private buildSchema<T>(t: T, name: string, schemaOptions, sch?: mongoose.Schema) {
     const Schema = mongoose.Schema;
 
     if (!sch) {
@@ -110,6 +111,11 @@ export class Typegoose {
         sch.virtual(key).set(value.set);
       }
     });
+
+    const indices = Reflect.getMetadata('typegoose:indices', t) || [];
+    for (let index of indices) {
+      sch.index(index.fields, index.options);
+    }
 
     return sch;
   }

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -113,7 +113,7 @@ export class Typegoose {
     });
 
     const indices = Reflect.getMetadata('typegoose:indices', t) || [];
-    for (let index of indices) {
+    for (const index of indices) {
       sch.index(index.fields, index.options);
     }
 


### PR DESCRIPTION
I have implemented adding of indexes to schema. This allows compound indexes and other index types (eg. GeoJSON). See README.md changes for example usage.

This PR solves following issues:
[#45](https://github.com/szokodiakos/typegoose/issues/45), [#141](https://github.com/szokodiakos/typegoose/issues/141), [#43](https://github.com/szokodiakos/typegoose/issues/43)

Implementation uses `reflect-metadata` to save index options to class and not as `./data` global. I believe this is better approach since this way more than one schema with the same name can be instantiated.