### PR TITLE
Add spaces to the message of NoMetadataError

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -19,8 +19,8 @@ export class NotStringTypeError extends Error {
 export class NoMetadataError extends Error {
   constructor(key: string) {
     super(
-      `There is no metadata for the "${key}" property.` +
-      'Check if emitDecoratorMetadata is enabled in tsconfig.json' +
+      `There is no metadata for the "${key}" property. ` +
+      'Check if emitDecoratorMetadata is enabled in tsconfig.json ' +
       'or check if you\'ve declared a sub document\'s class after usage.',
     );
   }


### PR DESCRIPTION
I got this message in the console because I forgot to enable `emitDecoratorMetadata`, and noticed that there were a few spaces missing.