### PR TITLE
reduce package size by including only lib directory (without tests) 

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "5.3.0",
   "description": "Define Mongoose models using TypeScript classes.",
   "main": "lib/typegoose.js",
+  "files": [
+    "lib/*.js",
+    "lib/*.d.ts"
+  ],
   "scripts": {
     "start": "npm run build && node ./lib/typegoose.js",
     "build": "rimraf lib && tsc",


### PR DESCRIPTION
This reduces package size from ~500kB unpacked to ~40kB unpacked.

There is no reason to include tests, typescript source and options, travis config and IDE settings in distribution package that is uploaded to npm. 