### PR TITLE
fix(): config for array enums must be set correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,31 @@
 language: node_js
 services:
-  - mongodb
+- mongodb
 node_js:
-  - "lts/*"
+- lts/*
 env:
-  - USE_OLDEST_NPM_VERSIONS=0
-  - USE_OLDEST_NPM_VERSIONS=1
+- USE_OLDEST_NPM_VERSIONS=0
+- USE_OLDEST_NPM_VERSIONS=1
 before_install:
-  - |
-    if [ $USE_OLDEST_NPM_VERSIONS -eq 1 ]
-    then
-      # Test against oldest allowed versions in package.json - Use sed to remove ^ characters
-      sed -i 's/"\^/"/g' package.json
-      npm i mongoose@5.0.0 reflect-metadata@0.1.12
-    else
-      npm i mongoose reflect-metadata
-    fi
+- |
+  if [ $USE_OLDEST_NPM_VERSIONS -eq 1 ]
+  then
+    # Test against oldest allowed versions in package.json - Use sed to remove ^ characters
+    sed -i 's/"\^/"/g' package.json
+    npm i mongoose@5.0.0 reflect-metadata@0.1.12
+  else
+    npm i mongoose reflect-metadata
+  fi
 script:
-  - npm test
-  - npm run coveralls
+- npm test
+- npm run coveralls
 deploy:
   provider: npm
-  email: "szokodiakos@gmail.com"
+  email: benedikt.huss@gmail.com
   skip_cleanup: true
   api_key:
-    secure: "N/HLbKkbEKPIISgHjjEi1gtBbexAwMWslXqkK1qnQSUDRtwwnIAc3xYZFhfRy0jThkKt8Jf3ATgt+luMcoR/LMDrAUXoATGuqn0unqC7bJKDvMeMTpliFCL+05XYv/TJmN+B4dqmTnzRun/f96ZPghbokm4MfCNYjGeY6jvE1ffdiu7NAnT4fXCfAcuH5rTkhdEZegJ89wKKUwHjX7mpg/Ofi/h36am4vlxOXZ25ErwQAX2XpaBgExWvUvbOFMZfHASOdSCa3WRwB0CvFdHRienfiWjNW85efao99xU2BPYpc2pq1MaebLKbWG7hB+OPuchG3XgP9XhYaMbGh/GGV1kstBwJqxSR4aT3OUAR4bDflwYz9kPDbDAKmco1oqA9GTXlKbtzHBpl0U9fWQz5EsHvDh1PcFu0GA4lXx7n6iO2RWnNsJepL5DvH1PyyDRMPov2bqk7ByjCmJEz+cxI/Js/hGch1SSjvX2r3XB7RCbvnWa72NeP1UlzN0bD7ZUjf86qTBuyhq8ohhREdalXS+oRq2neEhO5CMsjm74xbX0KRFfZe2q9Bi2hdycNAuVptDDHvpVTP2F20SWpkiQs5ToHQQiBKphY90SGbVtWJsvWBzAlueYCIguwgNHdmFicejAIGvZcE9hBo6Yoc2C3NOZJABsa+yeKkQw9MgcHaAg="
+    secure: ZRWIVSKkpzmfAdHumdrkVkpursZCP4Rz9l5g+fr9Tjm8yyAR536ohlycbhfjoPYyhPupXRAtWcishDsYzBGKmw7CAIs1XCmV5erIIe2i1zOhjtMYCgkH21h16BzqzD5oVZXd3bb0qL+nydbsje8ZiO5iac23GAQKLS2+mvniAPLZc7Qg3HMX5FjzzAzmA8tHBdDGsGCoFMAE3A3C9KHT74ujrtpMUYs036ulfrVJAI8InKDzqWnwx6JYAJiPiCzdGsb44ntwZ7DZ2Zxu/MZ1VWPljPos3nAk3UYeovSJwy57flzYk2qgKntfvsOpkycG4IWUQiw2wi5CX5lamZcrXFp86xANCSpm1HGC/VdvwS5MZn0BYcn2awgm34uQqbZpyWkEHV4Wf+F1Iv8ElAMXuZtZyHDLl0hYjsOy3UBTdwmKbgBwDzyytHOH5K2OZXq+IcVT95PzTuf6xmZkbEY2WWpNLlN4PLl3cLDdzLcIWRRAER3UDJDTOZAjEVfOhTlSugk02JjVfYbM1+plVeKsYWo/rJHgdOQ6AKW+O4pm6IGYHw8jAAYOB9T21nbNz/HPMHZ4PEVUKTMbzVWnnQwNsoxWYHfgwIXmLhmnLcv49ruQxz68Eks8qXs84E+N24ChKCUTmoAfxHDJj+Wg4TfkUZYjrqvtVuBgupwIGe00UDI=
   on:
-    branch: master
+    branches:
+      only:
+      - master

--- a/src/prop.ts
+++ b/src/prop.ts
@@ -143,10 +143,10 @@ const baseProp = (rawOptions, Type, target, key, isArray = false) => {
   const options = _.omit(rawOptions, ['ref', 'items']);
   if (isPrimitive(Type)) {
     if (isArray) {
-      schema[name][key][0] = {
+      schema[name][key] = {
         ...schema[name][key][0],
         ...options,
-        type: Type,
+        type: [Type],
       };
       return;
     }

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -71,6 +71,7 @@ describe('Typegoose', () => {
       expect(foundUser).to.have.property('age', 20);
       expect(foundUser).to.have.property('gender', Genders.MALE);
       expect(foundUser).to.have.property('role', Role.User);
+      expect(foundUser).to.have.property('roles').to.have.length(1).to.include(Role.Guest);
       expect(foundUser).to.have.property('job');
       expect(foundUser).to.have.property('car');
       expect(foundUser).to.have.property('languages').to.have.length(2).to.include('english').to.include('typescript');

--- a/src/test/models/user.ts
+++ b/src/test/models/user.ts
@@ -64,6 +64,9 @@ export class User extends Typegoose {
   @prop({ enum: Role })
   role: Role;
 
+  @arrayProp({ items: String, enum: Role, default: Role.Guest })
+  roles: Role[];
+
   // @prop({ required: true })
   @prop()
   job?: Job;


### PR DESCRIPTION
Creating the mongoose configuration for array enums are wrong. the whole config object is not needed to be wraped in an array, instead just wrap the `Type` with an array.

Fixes #202