### PR TITLE
Add missing string validator properties

### DIFF
--- a/src/prop.ts
+++ b/src/prop.ts
@@ -41,6 +41,9 @@ export interface ValidateStringOptions {
   minlength?: number | [number, string];
   maxlength?: number | [number, string];
   match?: RegExp | [RegExp, string];
+  lowercase?: boolean;
+  uppercase?: boolean;
+  trim?: boolean;
 }
 
 export type PropOptionsWithNumberValidate = PropOptions & ValidateNumberOptions;


### PR DESCRIPTION
According to https://mongoosejs.com/docs/schematypes.html#string-validators, these properties are missing :
- lowercase?: boolean;
- uppercase?: boolean;
- trim?: boolean;