### PR TITLE
Add string transformers to props options

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,27 @@ enum Gender {
 gender?: Gender;
 ```
 
+  - `lowercase`: for strings only; whether to always call .toLowerCase() on the value.
+
+```typescript
+@prop({ lowercase: true })
+nickName?: string;
+```
+
+  - `uppercase`: for strings only; whether to always call .toUpperCase() on the value.
+
+```typescript
+@prop({ uppercase: true })
+nickName?: string;
+```
+
+  - `trim`: for strings only; whether to always call .trim() on the value.
+
+```typescript
+@prop({ trim: true })
+nickName?: string;
+```
+
   - `default`: The provided value will be the default for that Mongoose property.
 
 ```typescript

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,10 @@ export interface IndexOptions {
   partialFilterExpression?: any;
   collation?: object;
   default_language?: string;
+
+  lowercase?: boolean; // whether to always call .toLowerCase() on the value
+  uppercase?: boolean; // whether to always call .toUpperCase() on the value
+  trim?: boolean; // whether to always call .trim() on the value
 }
 
 /**

--- a/src/prop.ts
+++ b/src/prop.ts
@@ -43,12 +43,21 @@ export interface ValidateStringOptions {
   match?: RegExp | [RegExp, string];
 }
 
+export interface TransformStringOptions {
+  lowercase?: boolean; // whether to always call .toLowerCase() on the value
+  uppercase?: boolean; // whether to always call .toUpperCase() on the value
+  trim?: boolean; // whether to always call .trim() on the value
+}
+
 export type PropOptionsWithNumberValidate = PropOptions & ValidateNumberOptions;
-export type PropOptionsWithStringValidate = PropOptions & ValidateStringOptions;
+export type PropOptionsWithStringValidate = PropOptions & TransformStringOptions & ValidateStringOptions;
 export type PropOptionsWithValidate = PropOptionsWithNumberValidate | PropOptionsWithStringValidate;
 
 const isWithStringValidate = (options: PropOptionsWithStringValidate) =>
   (options.minlength || options.maxlength || options.match);
+
+const isWithStringTransform = (options: PropOptionsWithStringValidate) =>
+  (options.lowercase || options.uppercase || options.trim);
 
 const isWithNumberValidate = (options: PropOptionsWithNumberValidate) =>
   (options.min || options.max);
@@ -132,6 +141,11 @@ const baseProp = (rawOptions, Type, target, key, isArray = false) => {
 
   if (isWithNumberValidate(rawOptions) && !isNumber(Type)) {
     throw new NotNumberTypeError(key);
+  }
+
+  // check for transform inconsistencies
+  if (isWithStringTransform(rawOptions) && !isString(Type)) {
+    throw new NotStringTypeError(key);
   }
 
   const instance = new Type();

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -21,6 +21,7 @@ describe('Typegoose', () => {
   it('should create a User with connections', async () => {
     const car = await Car.create({
       model: 'Tesla',
+      version: 'ModelS',
       price: mongoose.Types.Decimal128.fromString('50123.25'),
     });
 
@@ -83,6 +84,7 @@ describe('Typegoose', () => {
       expect(foundUser.job.jobType).to.have.property('field', 'IT');
       expect(foundUser.job.jobType).to.have.property('salery').to.be.a('number');
       expect(foundUser.car).to.have.property('model', 'Tesla');
+      expect(foundUser.car).to.have.property('version', 'models');
       expect(foundUser).to.have.property('previousJobs').to.have.length(2);
 
       expect(foundUser).to.have.property('fullName', 'John Doe');

--- a/src/test/models/car.ts
+++ b/src/test/models/car.ts
@@ -12,6 +12,9 @@ export class Car extends Typegoose {
   @prop({ required: true })
   model: string;
 
+  @prop({ lowercase: true })
+  version: string;
+
   @prop()
   isSedan?: boolean;
 


### PR DESCRIPTION
Add lowercase, uppsercase and trim to the list of possible options.
According to https://mongoosejs.com/docs/schematypes.html#string-validators, these properties are missing : - lowercase?: boolean; - uppercase?: boolean; - trim?: boolean; 
