### PR TITLE
Better support for Model middleware hooks

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -17,7 +17,7 @@ type TypegooseDoc<T> = T & MongooseDocument;
 type DocumentPreSerialFn<T> = (this: TypegooseDoc<T>, next: HookNextFn) => void;
 type DocumentPreParallelFn<T> = (this: TypegooseDoc<T>, next: HookNextFn, done: PreDoneFn) => void;
 
-type SimplePreSerialFn<T> = (next: HookNextFn) => void;
+type SimplePreSerialFn<T> = (next: HookNextFn, docs: any[]) => void;
 type SimplePreParallelFn<T> = (next: HookNextFn, done: PreDoneFn) => void;
 
 type DocumentPostFn<T> = (this: TypegooseDoc<T>, doc: TypegooseDoc<T>, next?: HookNextFn) => void;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -17,7 +17,7 @@ type TypegooseDoc<T> = T & MongooseDocument;
 type DocumentPreSerialFn<T> = (this: TypegooseDoc<T>, next: HookNextFn) => void;
 type DocumentPreParallelFn<T> = (this: TypegooseDoc<T>, next: HookNextFn, done: PreDoneFn) => void;
 
-type SimplePreSerialFn<T> = (next: HookNextFn, docs: any[]) => void;
+type SimplePreSerialFn<T> = (next: HookNextFn, docs?: any[]) => void;
 type SimplePreParallelFn<T> = (next: HookNextFn, done: PreDoneFn) => void;
 
 type DocumentPostFn<T> = (this: TypegooseDoc<T>, doc: TypegooseDoc<T>, next?: HookNextFn) => void;


### PR DESCRIPTION
When defining hooks on Model middleware functions (afaik only `insertMany`) moongoose will supply the docs as second argument. See https://github.com/Automattic/mongoose/pull/5116

This should enable it for Typegoose aswell.