### PR TITLE
Add missing "get" and "set" property options

### DIFF
--- a/src/prop.ts
+++ b/src/prop.ts
@@ -30,6 +30,8 @@ export interface BasePropOptions {
   sparse?: boolean;
   expires?: string | number;
   _id?: boolean;
+  get?: (value: any) => any;
+  set?: (value: any) => any;
 }
 
 export interface PropOptions extends BasePropOptions {

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -29,7 +29,7 @@ describe('Typegoose', () => {
       price: mongoose.Types.Decimal128.fromString('28189.25'),
     }, {
       model: 'Zastava',
-        price: mongoose.Types.Decimal128.fromString('1234.25'),
+      price: mongoose.Types.Decimal128.fromString('1234.25'),
     }]);
 
     const user = await User.create({
@@ -56,6 +56,7 @@ describe('Typegoose', () => {
         title: 'Manager',
       }],
       previousCars: [trabant.id, zastava.id],
+      encodedKey: 'This an sample string',
     });
 
     {
@@ -89,6 +90,7 @@ describe('Typegoose', () => {
 
       expect(foundUser).to.have.property('fullName', 'John Doe');
 
+      expect(foundUser).to.have.property('encodedKey', 'This an sample string');
 
       const [janitor, manager] = foundUser.previousJobs;
       expect(janitor).to.have.property('title', 'Janitor');
@@ -169,7 +171,7 @@ describe('Typegoose', () => {
 
     expect(savedUser.languages).to.include('Hungarian');
     expect(savedUser.previousJobs.length).to.be.above(0);
-     savedUser.previousJobs.map((prevJob) => {
+    savedUser.previousJobs.map((prevJob) => {
       expect(prevJob.startedAt).to.be.ok;
     });
   });
@@ -288,7 +290,7 @@ describe('getClassForDocument()', () => {
   it('Should validate email', async () => {
     try {
       await Person.create({
-          email: 'email',
+        email: 'email',
       });
       fail('Validation must fail.');
     } catch (e) {

--- a/src/test/models/user.ts
+++ b/src/test/models/user.ts
@@ -78,6 +78,12 @@ export class User extends Typegoose {
   @arrayProp({ itemsRef: Car })
   previousCars?: Ref<Car>[];
 
+  @prop({
+    set: (value) => value ? Buffer.from(value).toString('base64') : value,
+    get: (value: any) => value ? Buffer.from(value, 'base64').toString('ascii') : value,
+  })
+  encodedKey?: string;
+
   @staticMethod
   static findByAge(this: ModelType<User> & typeof User, age: number) {
     return this.findOne({ age });


### PR DESCRIPTION
As describe in mongoose doc, we can define "get" and "set" options to be used as property getter and setter : https://mongoosejs.com/docs/api.html#schematype_SchemaType-set