### PR TITLE
Extend schema with parent class only if there are any schema definitions available for it

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "start": "npm run build && node ./lib/typegoose.js",
     "build": "rimraf lib && tsc",
+    "prepare": "npm run build",
     "lint": "tslint --project tsconfig.json",
     "test": "npm run lint && nyc npm run mocha",
     "mocha": "npm run build && mocha ./lib --recursive --exit",
@@ -37,7 +38,7 @@
     "dotenv": "5.0.1",
     "mocha": "5.2.0",
     "mocha-lcov-reporter": "^1.3.0",
-    "mongoose": "^5.4.15",
+    "mongoose": "^5.5.3",
     "mongoose-findorcreate": "3.0.0",
     "nyc": "13.3.0",
     "prettier": "1.16.4",

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -46,8 +46,10 @@ export class Typegoose {
     let parentCtor = Object.getPrototypeOf(this.constructor.prototype).constructor;
     // iterate trough all parents
     while (parentCtor && parentCtor.name !== 'Typegoose' && parentCtor.name !== 'Object') {
-      // extend schema
-      sch = this.buildSchema<T>(t, parentCtor.name, schemaOptions, sch);
+      // extend schema only if we have a definition available for it
+      if(schema[parentCtor.name]) {
+        sch = this.buildSchema<T>(t, parentCtor.name, schemaOptions, sch);
+      }
       // next parent
       parentCtor = Object.getPrototypeOf(parentCtor.prototype).constructor;
     }


### PR DESCRIPTION
Currently, there is no check if the parent class has a valid schema which causes mongoose to complain since argument passed to schema.add will now be undefined.