### PR TITLE
 guard against undefined schema definitions in buildSchema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Typegoose
 
 [![Build Status](https://travis-ci.org/szokodiakos/typegoose.svg?branch=master)](https://travis-ci.org/szokodiakos/typegoose)
-[![Coverage Status](https://coveralls.io/repos/github/szokodiakos/typegoose/badge.svg?branch=master)](https://coveralls.io/github/szokodiakos/typegoose?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/szokodiakos/typegoose/badge.svg?branch=master#feb282019)](https://coveralls.io/github/szokodiakos/typegoose?branch=master)
 [![npm](https://img.shields.io/npm/dt/typegoose.svg)]()
 
 Define Mongoose models using TypeScript classes.
@@ -275,8 +275,8 @@ nickName?: string;
 
     // or
 
-    @prop({ validate: { 
-        validator: val => isEmail(val), 
+    @prop({ validate: {
+        validator: val => isEmail(val),
         message: `{VALUE} is not a valid email`
     }})
     email?: string;
@@ -288,14 +288,14 @@ nickName?: string;
 
     // you can also use multiple validators in an array.
 
-    @prop({ validate: 
+    @prop({ validate:
         [
-            { 
-                validator: val => isEmail(val), 
-                message: `{VALUE} is not a valid email`
-            }, 
             {
-                validator: val => isBlacklisted(val), 
+                validator: val => isEmail(val),
+                message: `{VALUE} is not a valid email`
+            },
+            {
+                validator: val => isBlacklisted(val),
                 message: `{VALUE} is blacklisted`
             }
         ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typegoose",
-  "version": "5.5.1",
+  "version": "5.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1526,9 +1526,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
+      "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -1816,9 +1816,9 @@
       }
     },
     "mongoose": {
-      "version": "5.4.15",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.4.15.tgz",
-      "integrity": "sha512-CodfapidWmPlU93ZmdQ8H9UGg5Mc/5MqEy8y5zNQKw+Kp1UwOzSEJY6zXJW76/5MBQER859KHl3rvHijVMsUMg==",
+      "version": "5.4.16",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.4.16.tgz",
+      "integrity": "sha512-1lGuXBBxs8KloHMe0mZGpC8L+l+flRFh3IoNf2lRmSaSMrpgEjrBHm6Aypfe2s+Y5xO0h7gua3TAZUplWpMxSw==",
       "dev": true,
       "requires": {
         "async": "2.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -514,9 +514,9 @@
       "dev": true
     },
     "bson": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.0.tgz",
-      "integrity": "sha512-9Aeai9TacfNtWXOYarkFJRW2CWo+dRon+fuLZYJmvLV3+MiUp0bEI6IAZfXEIg7/Pl/7IWlLaDnhzTsD81etQA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.1.tgz",
+      "integrity": "sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg==",
       "dev": true
     },
     "builtin-modules": {
@@ -1794,44 +1794,45 @@
       "dev": true
     },
     "mongodb": {
-      "version": "3.1.13",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.13.tgz",
-      "integrity": "sha512-sz2dhvBZQWf3LRNDhbd30KHVzdjZx9IKC0L+kSZ/gzYquCF5zPOgGqRz6sSCqYZtKP2ekB4nfLxhGtzGHnIKxA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.2.2.tgz",
+      "integrity": "sha512-xQ6apOOV+w7VFApdaJpWhYhzartpjIDFQjG0AwgJkLh7dBs7PTsq4A3Bia2QWpDohmAzTBIdQVLMqqLy0mwt3Q==",
       "dev": true,
       "requires": {
-        "mongodb-core": "3.1.11",
+        "mongodb-core": "3.2.2",
         "safe-buffer": "^5.1.2"
       }
     },
     "mongodb-core": {
-      "version": "3.1.11",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.11.tgz",
-      "integrity": "sha512-rD2US2s5qk/ckbiiGFHeu+yKYDXdJ1G87F6CG3YdaZpzdOm5zpoAZd/EKbPmFO6cQZ+XVXBXBJ660sSI0gc6qg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.2.2.tgz",
+      "integrity": "sha512-YRgC39MuzKL0uoGoRdTmV1e9m47NbMnYmuEx4IOkgWAGXPSEzRY7cwb3N0XMmrDMnD9vp7MysNyAriIIeGgIQg==",
       "dev": true,
       "requires": {
-        "bson": "^1.1.0",
+        "bson": "^1.1.1",
         "require_optional": "^1.0.1",
         "safe-buffer": "^5.1.2",
         "saslprep": "^1.0.0"
       }
     },
     "mongoose": {
-      "version": "5.4.16",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.4.16.tgz",
-      "integrity": "sha512-1lGuXBBxs8KloHMe0mZGpC8L+l+flRFh3IoNf2lRmSaSMrpgEjrBHm6Aypfe2s+Y5xO0h7gua3TAZUplWpMxSw==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.5.3.tgz",
+      "integrity": "sha512-zlIiBhWHd5+mG3qJPcajrj9bMzjWesJeLaJsVrKVpOZy0XplphiQ8Evk9GiXJqy9IwDVDkoRFfzmBeiiVx2VYQ==",
       "dev": true,
       "requires": {
         "async": "2.6.1",
-        "bson": "~1.1.0",
+        "bson": "~1.1.1",
         "kareem": "2.3.0",
-        "mongodb": "3.1.13",
-        "mongodb-core": "3.1.11",
+        "mongodb": "3.2.2",
+        "mongodb-core": "3.2.2",
         "mongoose-legacy-pluralize": "1.0.2",
         "mpath": "0.5.1",
         "mquery": "3.2.0",
         "ms": "2.1.1",
         "regexp-clone": "0.0.1",
         "safe-buffer": "5.1.2",
+        "sift": "7.0.1",
         "sliced": "1.0.1"
       },
       "dependencies": {
@@ -3370,6 +3371,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "sift": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-7.0.1.tgz",
+      "integrity": "sha512-oqD7PMJ+uO6jV9EQCl0LrRw1OwsiPsiFQR5AR30heR+4Dl7jBBbDLnNvWiak20tzZlSE1H7RB30SX/1j/YYT7g==",
       "dev": true
     },
     "signal-exit": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typegoose",
-  "version": "5.5.1",
+  "version": "5.6.0",
   "description": "Define Mongoose models using TypeScript classes.",
   "main": "lib/typegoose.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "start": "npm run build && node ./lib/typegoose.js",
     "build": "rimraf lib && tsc",
+    "prepare": "npm run build",
     "lint": "tslint --project tsconfig.json",
     "test": "npm run lint && nyc npm run mocha",
     "mocha": "npm run build && mocha ./lib --recursive --exit",
@@ -37,7 +38,7 @@
     "dotenv": "5.0.1",
     "mocha": "5.2.0",
     "mocha-lcov-reporter": "^1.3.0",
-    "mongoose": "^5.4.15",
+    "mongoose": "^5.5.3",
     "mongoose-findorcreate": "3.0.0",
     "nyc": "13.3.0",
     "prettier": "1.16.4",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -27,3 +27,9 @@ export class NoMetadataError extends Error {
     );
   }
 }
+
+export class UndefinedSchemaError extends Error {
+  constructor(key: string) {
+    super(`No schema definitions available for "${key}" property. Ensure there is a proplike decorator in your class definition.`);
+  }
+}

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -26,7 +26,7 @@ type TypegooseDoc<T> = T & MongooseDocument;
 type DocumentPreSerialFn<T> = (this: TypegooseDoc<T>, next: HookNextFn) => void;
 type DocumentPreParallelFn<T> = (this: TypegooseDoc<T>, next: HookNextFn, done: PreDoneFn) => void;
 
-type SimplePreSerialFn<T> = (next: HookNextFn) => void;
+type SimplePreSerialFn<T> = (next: HookNextFn, docs?: any[]) => void;
 type SimplePreParallelFn<T> = (next: HookNextFn, done: PreDoneFn) => void;
 
 type DocumentPostFn<T> = (this: TypegooseDoc<T>, doc: TypegooseDoc<T>, next?: HookNextFn) => void;

--- a/src/prop.ts
+++ b/src/prop.ts
@@ -3,7 +3,7 @@
 import * as mongoose from 'mongoose';
 
 import { schema, virtuals, methods } from './data';
-import { isPrimitive, initAsObject, initAsArray, isString, isNumber, isObject } from './utils';
+import { isPrimitive, initAsObject, initAsArray, isString, isNumber, isObject, isMap } from './utils';
 import { InvalidPropError, NotNumberTypeError, NotStringTypeError, NoMetadataError } from './errors';
 import { ObjectID } from 'bson';
 
@@ -32,6 +32,7 @@ export interface BasePropOptions {
   _id?: boolean;
   get?: (value: any) => any;
   set?: (value: any) => any;
+  of?: any;
 }
 
 export interface PropOptions extends BasePropOptions {
@@ -184,6 +185,15 @@ const baseProp = (rawOptions: any, Type: any, target: any, key: any, isArray = f
       ...schema[name][key],
       ...options,
       type: Object,
+    };
+    return;
+  }
+
+  if (isMap(Type) && !subSchema) {
+    schema[name][key] = {
+      ...schema[name][key],
+      ...options,
+      type: Map,
     };
     return;
   }

--- a/src/prop.ts
+++ b/src/prop.ts
@@ -178,6 +178,17 @@ const baseProp = (rawOptions: any, Type: any, target: any, key: any, isArray = f
     return;
   }
 
+  if (isMap(Type) && !subSchema) {
+    const defaults = { default: new Map };
+    schema[name][key] = {
+      ...schema[name][key],
+      ...defaults,
+      ...options,
+      type: Map,
+    };
+    return;
+  }
+
   // If the 'Type' is not a 'Primitive Type' and no subschema was found treat the type as 'Object'
   // so that mongoose can store it as nested document
   if (isObject(Type) && !subSchema) {
@@ -185,15 +196,6 @@ const baseProp = (rawOptions: any, Type: any, target: any, key: any, isArray = f
       ...schema[name][key],
       ...options,
       type: Object,
-    };
-    return;
-  }
-
-  if (isMap(Type) && !subSchema) {
-    schema[name][key] = {
-      ...schema[name][key],
-      ...options,
-      type: Map,
     };
     return;
   }

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -46,8 +46,10 @@ export class Typegoose {
     let parentCtor = Object.getPrototypeOf(this.constructor.prototype).constructor;
     // iterate trough all parents
     while (parentCtor && parentCtor.name !== 'Typegoose' && parentCtor.name !== 'Object') {
-      // extend schema
-      sch = this.buildSchema<T>(t, parentCtor.name, schemaOptions, sch);
+      // extend schema only if we have a definition available for it
+      if(schema[parentCtor.name]) {
+        sch = this.buildSchema<T>(t, parentCtor.name, schemaOptions, sch);
+      }
       // next parent
       parentCtor = Object.getPrototypeOf(parentCtor.prototype).constructor;
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 /** @format */
 
 import * as mongoose from 'mongoose';
+// import {  } from "util";
 
 import { schema, constructors } from './data';
 
@@ -42,6 +43,10 @@ export const initAsArray = (name: any, key: any) => {
     schema[name][key] = [{}];
   }
 };
+
+export const isMap = (Type: any) => {
+  return Map.prototype === Type.prototype;
+}
 
 export const getClassForDocument = (document: mongoose.Document): any => {
   const modelName = (document.constructor as mongoose.Model<typeof document>)


### PR DESCRIPTION
Currently, there is no check if the parent class has a valid schema which causes mongoose to complain since argument passed to schema.add will now be undefined.