### PR TITLE
fix arrayprops options handling for non-primitives

### DIFF
--- a/src/prop.ts
+++ b/src/prop.ts
@@ -191,7 +191,10 @@ const baseProp = (rawOptions: any, Type: any, target: any, key: any, isArray = f
       schema[name][key] = {
         ...schema[name][key][0],
         ...options,
-        type: [subSchema],
+        type: [{
+          ...(options._id === false ? { _id: false } : {}),
+          ...subSchema,
+        }],
       }
       return;
     }

--- a/src/prop.ts
+++ b/src/prop.ts
@@ -187,6 +187,14 @@ const baseProp = (rawOptions: any, Type: any, target: any, key: any, isArray = f
   }
 
   if (isArray) {
+    if (options) {
+      schema[name][key] = {
+        ...schema[name][key][0],
+        ...options,
+        type: [subSchema],
+      }
+      return;
+    }
     schema[name][key][0] = {
       ...schema[name][key][0],
       ...options,

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -55,6 +55,9 @@ describe('Typegoose', () => {
       }, {
         title: 'Manager',
       }],
+      futureJobs: [{
+        title: 'Mr President',
+      }],
       previousCars: [trabant.id, zastava.id],
     });
 

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -97,6 +97,9 @@ describe('Typegoose', () => {
       expect(janitor).to.have.property('title', 'Janitor');
       expect(manager).to.have.property('title', 'Manager');
 
+      const [president] = foundUser.futureJobs;
+      expect(president).not.to.have.property('_id')
+
       expect(foundUser).to.have.property('previousCars').to.have.length(2);
 
       const [foundTrabant, foundZastava] = foundUser.previousCars;

--- a/src/test/models/user.ts
+++ b/src/test/models/user.ts
@@ -78,7 +78,11 @@ export class User extends Typegoose {
   @arrayProp({ items: Job })
   previousJobs?: Job[];
 
-  @arrayProp({ items: Job, default: void 0 })
+  @arrayProp({
+    items: Job,
+    _id: false,
+    default: void 0,
+  })
   futureJobs?: Job[];
 
   @arrayProp({ itemsRef: Car })

--- a/src/test/models/user.ts
+++ b/src/test/models/user.ts
@@ -63,6 +63,9 @@ export class User extends Typegoose {
   @arrayProp({ items: String, enum: Role, default: Role.Guest })
   roles: Role[];
 
+  @arrayProp({ items: String, enum: Role, default: void 0 })
+  extraRoles?: Role[];
+
   @prop()
   job?: Job;
 
@@ -74,6 +77,9 @@ export class User extends Typegoose {
 
   @arrayProp({ items: Job })
   previousJobs?: Job[];
+
+  @arrayProp({ items: Job, default: void 0 })
+  futureJobs?: Job[];
 
   @arrayProp({ itemsRef: Car })
   previousCars?: Ref<Car>[];


### PR DESCRIPTION
Fixes arrayprops options handling for non-primitives.

what was sent to mongoose (Before):
```
const someArraySchema = new Schema({
   jobs: [...options, ...subSchema], // options get lost / etc
})
```

what is now sent to mongoose (After):
```
const someArraySchema = new Schema({
  jobs: {
     ...options,
     type: [subSchema]
  }
})
```