### PR TITLE
Add virtual populate options

### DIFF
--- a/src/prop.ts
+++ b/src/prop.ts
@@ -16,9 +16,9 @@ export type Validator =
   | ValidatorFunction
   | RegExp
   | {
-      validator: ValidatorFunction;
-      message?: string;
-    };
+    validator: ValidatorFunction;
+    message?: string;
+  };
 
 export interface BasePropOptions {
   required?: RequiredType;
@@ -53,9 +53,18 @@ export interface TransformStringOptions {
   trim?: boolean; // whether to always call .trim() on the value
 }
 
+export interface VirtualOptions {
+  ref: string;
+  localField: string;
+  foreignField: string;
+  justOne: boolean;
+  /** Set to true, when it is an "virtual populate-able" */
+  overwrite: boolean;
+}
+
 export type PropOptionsWithNumberValidate = PropOptions & ValidateNumberOptions;
 export type PropOptionsWithStringValidate = PropOptions & TransformStringOptions & ValidateStringOptions;
-export type PropOptionsWithValidate = PropOptionsWithNumberValidate | PropOptionsWithStringValidate;
+export type PropOptionsWithValidate = PropOptionsWithNumberValidate | PropOptionsWithStringValidate | VirtualOptions;
 
 const isWithStringValidate = (options: PropOptionsWithStringValidate) =>
   options.minlength || options.maxlength || options.match;
@@ -79,6 +88,7 @@ const baseProp = (rawOptions: any, Type: any, target: any, key: any, isArray = f
       virtuals[name][key] = {
         ...virtuals[name][key],
         get: isGetterSetter.get,
+        options: rawOptions,
       };
     }
 
@@ -92,6 +102,7 @@ const baseProp = (rawOptions: any, Type: any, target: any, key: any, isArray = f
       virtuals[name][key] = {
         ...virtuals[name][key],
         set: isGetterSetter.set,
+        options: rawOptions,
       };
     }
     return;

--- a/src/test/models/virtualprop.ts
+++ b/src/test/models/virtualprop.ts
@@ -1,0 +1,17 @@
+import { instanceMethod, prop, Ref, Typegoose } from '../../typegoose';
+
+export class Virtual extends Typegoose {
+    @prop({ required: true })
+    dummyVirtual?: string;
+
+    @prop({ ref: "VirtualSub", foreignField: "virtual", localField: "_id", justOne: false, overwrite: true })
+    public get virtualSubs() { return undefined; }
+}
+
+export class VirtualSub extends Typegoose {
+    @prop({ required: true, ref: Virtual })
+    virtual: Ref<Virtual>;
+
+    @prop({ required: true })
+    dummy: string;
+}

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -108,12 +108,16 @@ export class Typegoose {
     const getterSetters = virtuals[name];
     if (getterSetters) {
       for (const key of Object.keys(getterSetters)) {
-        if (getterSetters[key].get) {
-          sch.virtual(key).get(getterSetters[key].get);
-        }
+        if (getterSetters[key].options && getterSetters[key].options.overwrite) {
+          sch.virtual(key, getterSetters[key].options)
+        } else {
+          if (getterSetters[key].get) {
+            sch.virtual(key, getterSetters[key].options).get(getterSetters[key].get);
+          }
 
-        if (getterSetters[key].set) {
-          sch.virtual(key).set(getterSetters[key].set);
+          if (getterSetters[key].set) {
+            sch.virtual(key, getterSetters[key].options).set(getterSetters[key].set);
+          }
         }
       }
     }


### PR DESCRIPTION
- adding #271
- with tests
- and an "overwrite" value, to not set `.get & .set` only `.virtual()`

fixes #131 

example:
```ts
import { ObjectID } from "bson";
import * as mongoose from "mongoose";
import { prop, Ref, Typegoose } from "./typegoose";

class User extends Typegoose {
    @prop({ required: true })
    public name!: string;

    @prop({ foreignField: "user", localField: "_id", ref: "Posts", justOne: false, overwrite: true })
    public get posts() {
        console.log("args", arguments);
        return this.posts;
    }
}

class Posts extends Typegoose {
    @prop({ required: true, ref: User })
    public user!: Ref<User>;

    @prop()
    public message!: string;
}

const PostsModel = new Posts().getModelForClass(Posts);
const UserModel = new User().getModelForClass(User);

(async () => {
    mongoose.set("debug", true);
    await mongoose.connect(`mongodb://mongodb:27017/`, {
        useNewUrlParser: true,
        useFindAndModify: true,
        useCreateIndex: true,
        dbName: "295",
        user: "hasezoey",
        pass: "passwd",
        authSource: "admin",
        autoIndex: true
    });

    const user = await new UserModel({ name: "user1" }).save();
    const post1 = await new PostsModel({ message: "post1", user: user._id } as Posts).save();
    const post2 = await new PostsModel({ message: "post2", user: user._id } as Posts).save();
    const post3 = await new PostsModel({ message: "post3", user: new ObjectID() } as Posts).save();

    const newfound = await UserModel.findById(user._id).populate("posts").exec();
    console.log(newfound ? await newfound.posts : "undefined_");

    await mongoose.disconnect();
})();
```