### PR TITLE
Remove the setting of mongoose.Promise

### DIFF
--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -3,8 +3,6 @@
 import 'reflect-metadata';
 import * as mongoose from 'mongoose';
 
-(mongoose as any).Promise = global.Promise;
-
 import { constructors, hooks, methods, models, plugins, schema, virtuals } from './data';
 
 export * from './method';
@@ -109,7 +107,7 @@ export class Typegoose {
     if (getterSetters) {
       for (const key of Object.keys(getterSetters)) {
         if (getterSetters[key].options && getterSetters[key].options.overwrite) {
-          sch.virtual(key, getterSetters[key].options)
+          sch.virtual(key, getterSetters[key].options);
         } else {
           if (getterSetters[key].get) {
             sch.virtual(key, getterSetters[key].options).get(getterSetters[key].get);


### PR DESCRIPTION
When using typegoose its not always possible to plugin a custom promise library for mongoose in some projects (e.g. Bluebird) - [the line here](https://github.com/szokodiakos/typegoose/blob/master/src/typegoose.ts#L6) means that the order of importing typegoose matters, and its not always possible without adding complexity.

Now that mongoose [uses native promises by default](http://thecodebarbarian.com/introducing-mongoose-5.html) it should be possible to remove this safely.