### PR TITLE
Remove unused type in hooks.ts

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -29,7 +29,6 @@ type DocumentPreParallelFn<T> = (this: TypegooseDoc<T>, next: HookNextFn, done: 
 type SimplePreSerialFn<T> = (next: HookNextFn, docs?: any[]) => void;
 type SimplePreParallelFn<T> = (next: HookNextFn, done: PreDoneFn) => void;
 
-type DocumentPostFn<T> = (this: TypegooseDoc<T>, doc: TypegooseDoc<T>, next?: HookNextFn) => void;
 type ModelPostFn<T> = (result: any, next?: HookNextFn) => void;
 
 type PostNumberResponse<T> = (result: number, next?: HookNextFn) => void;


### PR DESCRIPTION
as the Title says  

I'm making an extra pr, because i dont know if this line should be kept, otherwise, free-to-merge  