### PR TITLE
Re-Work of the config with In-Memory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2295,9 +2295,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
       "dev": true
     },
     "lodash.flattendeep": {

--- a/test/config_default.json
+++ b/test/config_default.json
@@ -1,0 +1,11 @@
+{
+    "Memory": true,
+    "DataBase": "typegooseTest",
+    "Port": 27017,
+    "Auth": {
+        "DB": "",
+        "User": "",
+        "Passwd": ""
+    },
+    "IP": "localhost"
+}

--- a/test/utils/config.ts
+++ b/test/utils/config.ts
@@ -1,0 +1,55 @@
+interface IConfig {
+    Memory: boolean;
+    DataBase: string;
+    Port: number;
+    Auth: IAuth;
+    IP: string;
+}
+
+interface IAuth {
+    User: string;
+    Passwd: string;
+    DB: string;
+}
+
+enum EConfig {
+    MONGODB_IP = 'MongoDB IP is not specified!',
+    MONGODB_DB = 'MongoDB DataBase is not specified!',
+    MONGODB_PORT = 'MongoDB Port is not specified!',
+    MONGODB_AUTH = 'You should activate & use MongoDB Authentication!'
+}
+
+import * as fs from 'fs';
+const env: NodeJS.ProcessEnv = process.env; // just to write less
+
+let path: string = env.CONFIG ? env.CONFIG : './test/config.json';
+path = fs.existsSync(path) ? path : './test/config_default.json';
+
+const configRAW: Readonly<IConfig> =
+    JSON.parse(fs.readFileSync(path).toString());
+
+// ENV || CONFIG-FILE || DEFAULT
+const configFINAL: Readonly<IConfig> = {
+    Memory: (env.C_USE_IN_MEMORY === 'true' ? true : undefined) ||
+        (typeof configRAW.Memory === 'boolean' ? configRAW.Memory : true),
+    DataBase: env.C_DATABASE || configRAW.DataBase || 'typegooseTest',
+    Port: parseInt(env.C_PORT as string, 10) || configRAW.Port || 27017,
+    Auth: {
+        User: env.C_AUTH_USER || configRAW.Auth.User || '',
+        Passwd: env.C_AUTH_PASSWD || configRAW.Auth.Passwd || '',
+        DB: env.C_AUTH_DB || configRAW.Auth.DB || ''
+    },
+    IP: env.C_IP || configRAW.IP || 'mongodb'
+};
+
+function cb(text: string): void {
+    // tslint:disable-next-line:no-console
+    console.error(text);
+    process.exit(-1);
+}
+
+if (!configFINAL.IP) { cb(EConfig.MONGODB_IP); }
+if (!configFINAL.DataBase) { cb(EConfig.MONGODB_DB); }
+if (!configFINAL.Port) { cb(EConfig.MONGODB_PORT); }
+
+export { configFINAL as config };


### PR DESCRIPTION
- Reworked the config to be included again, to investigate the database after running a test / to just execute it on an remote database
- Modified the config & connect so, that the In-Memory option is default on, but can be disabled & changed
- Audit fix for mocha