### PR TITLE
add a public method for building schema out of a class

### DIFF
--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -44,7 +44,7 @@ export class Typegoose {
   ) {
     const name = this.constructor.name;
 
-    const sch = this.buildPublicSchema(existingMongoose, schemaOptions)
+    const sch = this.buildPublicSchema<T>(existingMongoose, schemaOptions)
 
     let model = mongoose.model.bind(mongoose);
     if (existingConnection) {
@@ -75,6 +75,7 @@ export class Typegoose {
       // next parent
       parentCtor = Object.getPrototypeOf(parentCtor.prototype).constructor;
     }
+    return sch
   }
 
   private buildSchema<T>(t: T, name: string, schemaOptions: any, sch?: mongoose.Schema) {

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -44,17 +44,7 @@ export class Typegoose {
   ) {
     const name = this.constructor.name;
 
-    // get schema of current model
-    let sch = this.buildSchema<T>(t, name, schemaOptions);
-    // get parents class name
-    let parentCtor = Object.getPrototypeOf(this.constructor.prototype).constructor;
-    // iterate trough all parents
-    while (parentCtor && parentCtor.name !== 'Typegoose' && parentCtor.name !== 'Object') {
-      // extend schema
-      sch = this.buildSchema<T>(t, parentCtor.name, schemaOptions, sch);
-      // next parent
-      parentCtor = Object.getPrototypeOf(parentCtor.prototype).constructor;
-    }
+    const sch = this.buildPublicSchema(existingMongoose, schemaOptions)
 
     let model = mongoose.model.bind(mongoose);
     if (existingConnection) {
@@ -67,6 +57,24 @@ export class Typegoose {
     constructors[name] = this.constructor;
 
     return models[name] as ModelType<this> & T;
+  }
+
+  public buildPublicSchema<T>(
+    t: T,  { existingMongoose, schemaOptions }: GetModelForClassOptions = {}
+  ){
+    const name = this.constructor.name;
+
+    // get schema of current model
+    let sch = this.buildSchema<T>(t, name, schemaOptions);
+    // get parents class name
+    let parentCtor = Object.getPrototypeOf(this.constructor.prototype).constructor;
+    // iterate trough all parents
+    while (parentCtor && parentCtor.name !== 'Typegoose' && parentCtor.name !== 'Object') {
+      // extend schema
+      sch = this.buildSchema<T>(t, parentCtor.name, schemaOptions, sch);
+      // next parent
+      parentCtor = Object.getPrototypeOf(parentCtor.prototype).constructor;
+    }
   }
 
   private buildSchema<T>(t: T, name: string, schemaOptions: any, sch?: mongoose.Schema) {


### PR DESCRIPTION
Working with feathers-mongoose and discriminators, I needed the schema w/o it being registered automatically as a model.
The public method i've added, slices the part from the code that makes the magic happen and exposes it.