### PR TITLE
Docs, typedoc

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,6 +6,7 @@
 - Make sure you have run tslint & if something should come up, fix it to keep the code in one style
 - When you add documentation please make sure to keep the existing style
 - Make sure you read [Mastering-Markdown](https://guides.github.com/features/mastering-markdown/), thanks
+- Make sure when you make documentation of a something, you use the [TSDoc standard](https://api-extractor.com/pages/tsdoc/doc_comment_syntax/), not JSDoc, thanks
 
 ---
 *this is just the base, changes will occure*

--- a/.github/ISSUE_TEMPLATE/feature parity.md
+++ b/.github/ISSUE_TEMPLATE/feature parity.md
@@ -9,10 +9,10 @@ assignees: ''
 ---
 *please remove the parts in "---"*
 
-## What to include in your Questions
+## How to Structure your Feature Parity request
 
 - remove "not needed" from your parity below
-- Make sure you read [Mastering-Markdown](https://guides.github.com/features/mastering-markdown/) , thanks
+- Make sure you read [Mastering-Markdown](https://guides.github.com/features/mastering-markdown/), thanks
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,25 @@
+---
+name: Feature
+about: Request a feature
+title: '[Request] '
+labels: request
+assignees: ''
+---
+
+---
+*please remove the parts in "---"*
+
+## How to Structure your Feature request
+
+- When you have an Implementation Idea, remove "*no*"
+- Make sure you read [Mastering-Markdown](https://guides.github.com/features/mastering-markdown/), thanks
+
+---
+
+## Describe what you need | want
+
+description here
+
+## Do you have already an idea for the implementation?
+
+*no*

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -13,6 +13,6 @@ assignees: ''
 
 - Make sure you provide an understandable question
 - Make sure you provide all the needed code
-- Make sure you read [Mastering-Markdown](https://guides.github.com/features/mastering-markdown/) , thanks
+- Make sure you read [Mastering-Markdown](https://guides.github.com/features/mastering-markdown/), thanks
 
 ---

--- a/.gitignore
+++ b/.gitignore
@@ -228,3 +228,6 @@ lib
 
 # the config
 test/config.json
+
+# typedoc docs folder
+doc/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ before_install:
   # sed -i 's/"\^/"/g' package.json
   npm i mongoose@5.5.14 --no-save
 script:
-# Audit to make sure there are no vulnerabilities
-- npm audit
+# Audit to make sure there are no vulnerabilities, but do not affect the whole build
+- (npm audit || exit 0)
 # Test everything
 - npm test
 deploy:

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ class User extends Typegoose {
   @prop()
   job?: Job;
 
-  @prop({ ref: Car, required: true })
+  @prop({ ref: Car })
   car: Ref<Car>;
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -174,6 +174,65 @@
         "@types/chai": "*"
       }
     },
+    "@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
+    },
+    "@types/fs-extra": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
+      "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "dev": true,
+      "requires": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/handlebars": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.1.0.tgz",
+      "integrity": "sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==",
+      "dev": true,
+      "requires": {
+        "handlebars": "*"
+      }
+    },
+    "@types/highlight.js": {
+      "version": "9.12.3",
+      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.3.tgz",
+      "integrity": "sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.136",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.136.tgz",
+      "integrity": "sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA==",
+      "dev": true
+    },
+    "@types/marked": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.4.2.tgz",
+      "integrity": "sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg==",
+      "dev": true
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
+    },
     "@types/mocha": {
       "version": "5.2.7",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
@@ -205,6 +264,16 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.0.tgz",
       "integrity": "sha512-7IGHZQfRfa0bCd7zUBVUGFKFn31SpaLDFfNoCAqkTGQO5JlHC9BwQA/CG9KZlABFxIUtXznyFgechjPQEGrUTg==",
       "dev": true
+    },
+    "@types/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-bZgjwIWu9gHCjirKJoOlLzGi5N0QgZ5t7EXEuoqyWCHTuSddURXo3FOBYDyRPNOWzZ6NbkLvZnVkn483Y/tvcQ==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "*",
+        "@types/node": "*"
+      }
     },
     "agent-base": {
       "version": "4.3.0",
@@ -1514,6 +1583,17 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
     },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1772,6 +1852,12 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "highlight.js": {
+      "version": "9.15.8",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.8.tgz",
+      "integrity": "sha512-RrapkKQWwE+wKdF73VsOa2RQdIoO3mxwJ4P8mhbI6KYJUraUHRKM5w5zQQKXNk0xNL4UVRdulV9SBJcmzJNzVA==",
+      "dev": true
+    },
     "hosted-git-info": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
@@ -1831,6 +1917,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "interpret": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
       "dev": true
     },
     "invert-kv": {
@@ -2224,6 +2316,15 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -2378,6 +2479,12 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "marked": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
+      "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==",
+      "dev": true
     },
     "md5-file": {
       "version": "4.0.0",
@@ -3846,6 +3953,12 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -3959,6 +4072,15 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
+      }
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
       }
     },
     "reflect-metadata": {
@@ -4195,6 +4317,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "sift": {
       "version": "7.0.1",
@@ -4838,6 +4971,45 @@
       "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
       "dev": true
     },
+    "typedoc": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.14.2.tgz",
+      "integrity": "sha512-aEbgJXV8/KqaVhcedT7xG6d2r+mOvB5ep3eIz1KuB5sc4fDYXcepEEMdU7XSqLFO5hVPu0nllHi1QxX2h/QlpQ==",
+      "dev": true,
+      "requires": {
+        "@types/fs-extra": "^5.0.3",
+        "@types/handlebars": "^4.0.38",
+        "@types/highlight.js": "^9.12.3",
+        "@types/lodash": "^4.14.110",
+        "@types/marked": "^0.4.0",
+        "@types/minimatch": "3.0.3",
+        "@types/shelljs": "^0.8.0",
+        "fs-extra": "^7.0.0",
+        "handlebars": "^4.0.6",
+        "highlight.js": "^9.13.1",
+        "lodash": "^4.17.10",
+        "marked": "^0.4.0",
+        "minimatch": "^3.0.0",
+        "progress": "^2.0.0",
+        "shelljs": "^0.8.2",
+        "typedoc-default-themes": "^0.5.0",
+        "typescript": "3.2.x"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+          "integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==",
+          "dev": true
+        }
+      }
+    },
+    "typedoc-default-themes": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
+      "integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=",
+      "dev": true
+    },
     "typescript": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
@@ -4892,6 +5064,12 @@
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test": "npm run lint && nyc npm run mocha",
     "mocha": "npm run build && mocha \"./test/*.ts\" --timeout 15000",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "clean": "rimraf lib && rm .tsbuildinfo && rimraf .nyc_output && rimraf coverage"
+    "clean": "rimraf lib && rm .tsbuildinfo && rimraf .nyc_output && rimraf coverage && rimraf doc",
+    "doc": "typedoc --out ./doc ./src --mode modules"
   },
   "repository": {
     "type": "git",
@@ -34,10 +35,10 @@
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^0.1.3",
     "@types/chai": "4.1.3",
+    "@types/chai-as-promised": "^7.1.0",
     "@types/mocha": "^5.2.7",
     "@types/mongoose": "^5.5.0",
     "@types/node": "8.10.0",
-    "@types/chai-as-promised": "^7.1.0",
     "chai": "4.1.2",
     "chai-as-promised": "7.1.1",
     "coveralls": "^3.0.4",
@@ -53,6 +54,7 @@
     "ts-node": "^8.3.0",
     "tslint": "5.17.0",
     "tslint-config-prettier": "1.18.0",
+    "typedoc": "^0.14.2",
     "typescript": "3.5.1"
   },
   "dependencies": {

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,10 +1,15 @@
 /** @format */
 
 export const methods = { staticMethods: {}, instanceMethods: {} };
+/** Schema Collection */
 export const schema = {};
+/** Models Collection */
 export const models = {};
+/** Virtuals Collection */
 export const virtuals = {};
+/** Hooks Collection */
 export const hooks = {};
+/** Plugins Collection */
 export const plugins = {};
 // tslint:disable-next-line: ban-types
 export const constructors: { [key: string]: Function } = {};

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -66,6 +66,7 @@ interface Hooks {
   post<T>(method: ModelMethod, fn: ModelPostFn<T> | PostMultipleResponse<T>): ClassDecorator;
 }
 
+// Note: Documentation for the hooks cant be added without adding it to *every* overload
 const hooks: Hooks = {
   pre(...args) {
     return (constructor: any) => {
@@ -79,12 +80,18 @@ const hooks: Hooks = {
   },
 };
 
-const addToHooks = (name, hookType: 'pre' | 'post', args) => {
+/**
+ * Add a hook to the hooks Array
+ * @param name With wich name should they be registered
+ * @param hookType What type is it
+ * @param args All Arguments, that should be passed-throught
+ */
+function addToHooks(name: string, hookType: 'pre' | 'post', args: any) {
   if (!hooksData[name]) {
     hooksData[name] = { pre: [], post: [] };
   }
   hooksData[name][hookType].push(args);
-};
+}
 
 export const pre = hooks.pre;
 export const post = hooks.post;

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,12 +62,18 @@ export interface IndexOptions {
 
 /**
  * Defines an index (most likely compound) for this schema.
+ * @param fields Wich fields to give the Options
  * @param options Options to pass to MongoDB driver's createIndex() function
+ * @example Example:
+ * ```
+ *  @index({ article: 1, user: 1 }, { unique: true })
+ *  class Name extends Typegoose {}
+ * ```
  */
-export const index = (fields: any, options?: IndexOptions) => {
+export function index(fields: any, options?: IndexOptions) {
   return (constructor: any) => {
     const indices = Reflect.getMetadata('typegoose:indices', constructor) || [];
     indices.push({ fields, options });
     Reflect.defineMetadata('typegoose:indices', indices, constructor);
   };
-};
+}

--- a/src/method.ts
+++ b/src/method.ts
@@ -4,7 +4,14 @@ import { methods } from './data';
 
 type MethodType = 'instanceMethods' | 'staticMethods';
 
-const baseMethod = (target: any, key: string, descriptor: TypedPropertyDescriptor<any>, methodType: MethodType) => {
+/**
+ * Base Function for staticMethod & instanceMethod
+ * @param target <no info>
+ * @param key <no info>
+ * @param descriptor <no info>
+ * @param methodType What type it is
+ */
+function baseMethod(target: any, key: string, descriptor: TypedPropertyDescriptor<any>, methodType: MethodType) {
   if (descriptor === undefined) {
     descriptor = Object.getOwnPropertyDescriptor(target, key);
   }
@@ -26,10 +33,35 @@ const baseMethod = (target: any, key: string, descriptor: TypedPropertyDescripto
     ...methods[methodType][name],
     [key]: method,
   };
-};
+}
 
-export const staticMethod = (target: any, key: string, descriptor: TypedPropertyDescriptor<any>) =>
-  baseMethod(target, key, descriptor, 'staticMethods');
+/**
+ * Set the function below as a Static Method
+ * Note: you need to add static before the name
+ * @example Example:
+ * ```
+ *  @staticMethod
+ *  public static hello() {}
+ * ```
+ * @param target <no info>
+ * @param key <no info>
+ * @param descriptor <no info>
+ */
+export function staticMethod(target: any, key: string, descriptor: TypedPropertyDescriptor<any>) {
+  return baseMethod(target, key, descriptor, 'staticMethods');
+}
 
-export const instanceMethod = (target: any, key: string, descriptor: TypedPropertyDescriptor<any>) =>
-  baseMethod(target, key, descriptor, 'instanceMethods');
+/**
+ * Set the function below as an Instance Method
+ * @example Example:
+ * ```
+ *  @instanceMethod
+ *  public hello() {}
+ * ```
+ * @param target <no info>
+ * @param key <no info>
+ * @param descriptor <no info>
+ */
+export function instanceMethod(target: any, key: string, descriptor: TypedPropertyDescriptor<any>) {
+  return baseMethod(target, key, descriptor, 'instanceMethods');
+}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -2,10 +2,17 @@
 
 import { plugins } from './data';
 
-export const plugin = (mongoosePlugin: any, options?: any) => (constructor: any) => {
-  const name: string = constructor.name;
-  if (!plugins[name]) {
-    plugins[name] = [];
-  }
-  plugins[name].push({ mongoosePlugin, options });
-};
+/**
+ * Add a Middleware-Plugin
+ * @param mongoosePlugin The Plugin to plug-in
+ * @param options Options for the Plugin, if any
+ */
+export function plugin(mongoosePlugin: any, options?: any) {
+  return (constructor: any) => {
+    const name: string = constructor.name;
+    if (!plugins[name]) {
+      plugins[name] = [];
+    }
+    plugins[name].push({ mongoosePlugin, options });
+  };
+}

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -1,10 +1,12 @@
 /** @format */
 
+/* imports */
 import * as mongoose from 'mongoose';
 import 'reflect-metadata';
 
 import { constructors, hooks, methods, models, plugins, schema, virtuals } from './data';
 
+/* exports */
 export * from './method';
 export * from './prop';
 export * from './hooks';
@@ -16,12 +18,29 @@ export type InstanceType<T> = T & mongoose.Document;
 export type ModelType<T> = mongoose.Model<InstanceType<T>> & T;
 
 export interface GetModelForClassOptions {
+  /** An Existing Mongoose Connection */
   existingMongoose?: mongoose.Mongoose;
+  /** Supports all Mongoose's Schema Options */
   schemaOptions?: mongoose.SchemaOptions;
+  /** An Existing Connection */
   existingConnection?: mongoose.Connection;
 }
 
+/**
+ * Main Class
+ */
 export class Typegoose {
+  /**
+   * Get a Model for a Class
+   * Executes .setModelForClass if it cant find it already
+   * @param t The uninitialized Class
+   * @param __namedParameters The Options
+   * @param existingMongoose An Existing Mongoose Connection
+   * @param schemaOptions Supports all Mongoose's Schema Options
+   * @param existingConnection An Existing Connection
+   * @returns The Model
+   * @public
+   */
   public getModelForClass<T>(
     t: T,
     { existingMongoose, schemaOptions, existingConnection }: GetModelForClassOptions = {}
@@ -38,6 +57,16 @@ export class Typegoose {
     return models[name] as ModelType<this> & T;
   }
 
+  /**
+   * Builds the Schema & The Model
+   * @param t The uninitialized Class
+   * @param __namedParameters The Options
+   * @param existingMongoose An Existing Mongoose Connection
+   * @param schemaOptions Supports all Mongoose's Schema Options
+   * @param existingConnection An Existing Connection
+   * @returns The Model
+   * @public
+   */
   public setModelForClass<T>(
     t: T,
     { existingMongoose, schemaOptions, existingConnection }: GetModelForClassOptions = {}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,10 +4,21 @@ import * as mongoose from 'mongoose';
 
 import { constructors, schema } from './data';
 
-export const isPrimitive = (Type: any) =>
-  ['String', 'Number', 'Boolean', 'Date', 'Decimal128', 'ObjectID'].includes(Type.name);
+/**
+ * Returns true, if it includes the Type
+ * @param Type The Type
+ * @returns true, if it includes it
+ */
+export function isPrimitive(Type: any): boolean {
+  return ['String', 'Number', 'Boolean', 'Date', 'Decimal128', 'ObjectID'].includes(Type.name);
+}
 
-export const isObject = (Type: any) => {
+/**
+ * Returns true, if it is an Object
+ * @param Type The Type
+ * @returns true, if it is an Object
+ */
+export function isObject(Type: any): boolean {
   let prototype = Type.prototype;
   let name = Type.name;
   while (name) {
@@ -19,31 +30,59 @@ export const isObject = (Type: any) => {
   }
 
   return false;
-};
+}
 
-export const isNumber = (Type: any) => Type.name === 'Number';
+/**
+ * Returns true, if it is an Number
+ * @param Type The Type
+ * @returns true, if it is an Number
+ */
+export function isNumber(Type: any): boolean {
+  return Type.name === 'Number';
+}
 
-export const isString = (Type: any) => Type.name === 'String';
+/**
+ * Returns true, if it is an String
+ * @param Type The Type
+ * @returns true, if it is an String
+ */
+export function isString(Type: any): boolean {
+  return Type.name === 'String';
+}
 
-export const initAsObject = (name, key) => {
+/**
+ * Initialize as Object
+ * @param name <no info>
+ * @param key <no info>
+ */
+export function initAsObject(name, key): void {
   if (!schema[name]) {
     schema[name] = {};
   }
   if (!schema[name][key]) {
     schema[name][key] = {};
   }
-};
+}
 
-export const initAsArray = (name: any, key: any) => {
+/**
+ * Initialize as Array
+ * @param name <no info>
+ * @param key <no info>
+ */
+export function initAsArray(name: any, key: any): void {
   if (!schema[name]) {
     schema[name] = {};
   }
   if (!schema[name][key]) {
     schema[name][key] = [{}];
   }
-};
+}
 
-export const getClassForDocument = (document: mongoose.Document): any => {
+/**
+ * Get the Class for a given Document
+ * @param document The Document
+ */
+export function getClassForDocument(document: mongoose.Document): any {
   const modelName = (document.constructor as mongoose.Model<typeof document>).modelName;
   return constructors[modelName];
-};
+}

--- a/test/models/person.ts
+++ b/test/models/person.ts
@@ -1,10 +1,10 @@
 /** @format */
 
-import * as tg from '../../src/typegoose';
+import { instanceMethod, pre, prop, staticMethod } from '../../src/typegoose';
 import { PersistentModel } from './PersistentModel';
 
 // add a pre-save hook to PersistentModel
-@tg.pre<PersistentModel>('save', function (next) {
+@pre<PersistentModel>('save', function (next) {
   if (!this.createdAt) {
     this.createdAt = new Date();
   }
@@ -12,17 +12,17 @@ import { PersistentModel } from './PersistentModel';
 })
 export class Person extends PersistentModel {
   // add new property
-  @tg.prop({ required: true, validate: /^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$/ })
+  @prop({ required: true, validate: /^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$/ })
   public email: string;
 
   // override instanceMethod
-  @tg.instanceMethod
+  @instanceMethod
   public getClassName() {
     return 'Person';
   }
 
   // override staticMethod
-  @tg.staticMethod
+  @staticMethod
   public static getStaticName() {
     return 'Person';
   }

--- a/test/utils/config.ts
+++ b/test/utils/config.ts
@@ -1,3 +1,5 @@
+import * as fs from 'fs';
+
 interface IConfig {
     Memory: boolean;
     DataBase: string;
@@ -19,7 +21,6 @@ enum EConfig {
     MONGODB_AUTH = 'You should activate & use MongoDB Authentication!'
 }
 
-import * as fs from 'fs';
 const env: NodeJS.ProcessEnv = process.env; // just to write less
 
 let path: string = env.CONFIG ? env.CONFIG : './test/config.json';
@@ -42,14 +43,17 @@ const configFINAL: Readonly<IConfig> = {
     IP: env.C_IP || configRAW.IP || 'mongodb'
 };
 
+/** Small callback for the tests below */
 function cb(text: string): void {
     // tslint:disable-next-line:no-console
     console.error(text);
     process.exit(-1);
 }
 
-if (!configFINAL.IP) { cb(EConfig.MONGODB_IP); }
-if (!configFINAL.DataBase) { cb(EConfig.MONGODB_DB); }
-if (!configFINAL.Port) { cb(EConfig.MONGODB_PORT); }
+if (!configFINAL.Memory) {
+    if (!configFINAL.IP) { cb(EConfig.MONGODB_IP); }
+    if (!configFINAL.DataBase) { cb(EConfig.MONGODB_DB); }
+    if (!configFINAL.Port) { cb(EConfig.MONGODB_PORT); }
+}
 
 export { configFINAL as config };

--- a/test/utils/mongooseConnect.ts
+++ b/test/utils/mongooseConnect.ts
@@ -10,6 +10,7 @@ if (config.Memory) {
   instance = new MongoMemoryServer();
 }
 
+/** is it the First time connecting in this test run? */
 let isFirst = true;
 /**
  * Make a Connection to MongoDB
@@ -48,6 +49,7 @@ export async function connect(): Promise<void> {
 
 /**
  * Disconnect from MongoDB
+ * @returns when it is disconnected
  */
 export async function disconnect(): Promise<any> {
   await mongoose.disconnect();


### PR DESCRIPTION
- includes #92 

---

- adding typedoc as a dev-depdendency
- adding script to generate the docs
- adding "doc/" to the "clean" script
- making `npm audit` not failing the build (it just reports it)

---

- remove TransformStringOptions from ValidateStringOptions
- modify person model to a bit cleaner style
- config
  - config: adding a small check if config.Memory is enabled
  - config: moving "import" to the top of the file, like in any other file

---

- adding a note to CONTRIBUTING
- adding template to request a feature
- adding minor fixes to other Issue Templates

---

- adding docs for:
  - prop
  - plugin
  - method
  - index
  - utils
  - hooks
  - data (some)

---

(closes #92)