### PR TITLE
Allow refType to be defined in @prop and @arrayProp

### DIFF
--- a/src/prop.ts
+++ b/src/prop.ts
@@ -8,6 +8,11 @@ import { initAsArray, initAsObject, isNumber, isObject, isPrimitive, isString } 
 export type Func = (...args: any[]) => any;
 
 export type RequiredType = boolean | [boolean, string] | string | Func | [Func, string];
+export type RefType = number | string | mongoose.Types.ObjectId | Buffer;
+export type RefSchemaType = typeof mongoose.Schema.Types.Number |
+  typeof mongoose.Schema.Types.String |
+  typeof mongoose.Schema.Types.Buffer |
+  typeof mongoose.Schema.Types.ObjectId;
 
 export type ValidatorFunction = (value: any) => boolean | Promise<boolean>;
 export type Validator =
@@ -58,6 +63,8 @@ export interface PropOptions extends BasePropOptions {
   ref?: any;
   /** Take the Path and try to resolve it to a Model */
   refPath?: string;
+  /** Type of id field of referenced documents (default: ObjectId) */
+  refType?: RefSchemaType;
   /** 
    * Give the Property an alias in the output
    * Note: you should include the alias as a variable in the class, but not with a prop decorator
@@ -198,34 +205,36 @@ function baseProp(rawOptions: any, Type: any, target: any, key: string, whatis: 
   }
 
   const ref = rawOptions.ref;
+  const refType = rawOptions.refType || mongoose.Schema.Types.ObjectId;
   if (typeof ref === 'string') {
     schema[name][key] = {
       ...schema[name][key],
-      type: mongoose.Schema.Types.ObjectId,
+      type: refType,
       ref,
     };
     return;
   } else if (ref) {
     schema[name][key] = {
       ...schema[name][key],
-      type: mongoose.Schema.Types.ObjectId,
+      type: refType,
       ref: ref.name,
     };
     return;
   }
 
   const itemsRef = rawOptions.itemsRef;
+  const itemsRefType = rawOptions.itemsRefType || mongoose.Schema.Types.ObjectId;
   if (typeof itemsRef === 'string') {
     schema[name][key][0] = {
       ...schema[name][key][0],
-      type: mongoose.Schema.Types.ObjectId,
+      type: itemsRefType,
       ref: itemsRef,
     };
     return;
   } else if (itemsRef) {
     schema[name][key][0] = {
       ...schema[name][key][0],
-      type: mongoose.Schema.Types.ObjectId,
+      type: itemsRefType,
       ref: itemsRef.name,
     };
     return;
@@ -235,7 +244,7 @@ function baseProp(rawOptions: any, Type: any, target: any, key: string, whatis: 
   if (refPath && typeof refPath === 'string') {
     schema[name][key] = {
       ...schema[name][key],
-      type: mongoose.Schema.Types.ObjectId,
+      type: refType,
       refPath,
     };
     return;
@@ -245,7 +254,7 @@ function baseProp(rawOptions: any, Type: any, target: any, key: string, whatis: 
   if (itemsRefPath && typeof itemsRefPath === 'string') {
     schema[name][key][0] = {
       ...schema[name][key][0],
-      type: mongoose.Schema.Types.ObjectId,
+      type: itemsRefType,
       refPath: itemsRefPath,
     };
     return;
@@ -395,7 +404,10 @@ export interface ArrayPropOptions extends BasePropOptions {
   itemsRef?: any;
   /** Same as {@link PropOptions.refPath}, only that it is for an array */
   itemsRefPath?: any;
+  /** Same as {@link PropOptions.refType}, only that it is for an array */
+  itemsRefType?: RefSchemaType;
 }
+
 export interface MapPropOptions extends BasePropOptions {
   of?: any;
   mapDefault?: any;
@@ -427,4 +439,4 @@ export function arrayProp(options: ArrayPropOptions) {
 /**
  * Reference another Model
  */
-export type Ref<T> = T | mongoose.Schema.Types.ObjectId;
+export type Ref<R, T extends RefType = mongoose.Types.ObjectId> = R | T;

--- a/src/typeguards.ts
+++ b/src/typeguards.ts
@@ -2,14 +2,14 @@
 
 import * as mongoose from 'mongoose';
 
-import { Ref } from './prop';
+import { Ref, RefType } from './prop';
 import { InstanceType } from './typegoose';
 
 /**
  * Check if the given document is already populated
  * @param doc The Ref with uncertain type
  */
-export function isDocument<T>(doc: Ref<T>): doc is InstanceType<T> {
+export function isDocument<T, S extends RefType>(doc: Ref<T, S>): doc is InstanceType<T> {
   return doc instanceof mongoose.Model;
 }
 
@@ -17,6 +17,6 @@ export function isDocument<T>(doc: Ref<T>): doc is InstanceType<T> {
  * Check if the given array is already populated
  * @param docs The Array of Refs with uncertain type
  */
-export function isDocumentArray<T>(docs: Ref<T>[]): docs is InstanceType<T>[] {
+export function isDocumentArray<T, S extends RefType>(docs: Ref<T, S>[]): docs is InstanceType<T>[] {
   return Array.isArray(docs) && docs.every(v => isDocument(v));
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -5,6 +5,7 @@ import { suite as BigUserTest } from './tests/biguser.test';
 import { suite as IndexTests } from './tests/db_index.test';
 import { suite as GCFDTest } from './tests/getClassForDocument.test';
 import { suite as HookTest } from './tests/hooks.test';
+import { suite as RefTest } from './tests/ref.test';
 import { suite as ShouldAddTest } from './tests/shouldAdd.test';
 import { suite as StringValidatorTests } from './tests/stringValidator.test';
 import { suite as TypeguardsTest } from './tests/typeguards.test';
@@ -30,4 +31,6 @@ describe('Typegoose', () => {
   describe('String Validators', StringValidatorTests.bind(this));
 
   describe('getClassForDocument()', GCFDTest.bind(this));
+
+  describe('Ref tests', RefTest.bind(this));
 });

--- a/test/models/refTests.ts
+++ b/test/models/refTests.ts
@@ -1,0 +1,82 @@
+import * as mongoose from 'mongoose';
+
+import { arrayProp, prop, Ref, Typegoose } from '../../src/typegoose';
+
+export class RefTestBuffer extends Typegoose {
+  @prop()
+  public _id: mongoose.Schema.Types.Buffer;
+}
+
+export class RefTestNumber extends Typegoose {
+  @prop()
+  public _id: number;
+}
+
+export class RefTestString extends Typegoose {
+  @prop()
+  public _id: string;
+}
+
+export const RefTestBufferModel = new RefTestBuffer().getModelForClass(RefTestBuffer);
+export const RefTestNumberModel = new RefTestNumber().getModelForClass(RefTestNumber);
+export const RefTestStringModel = new RefTestString().getModelForClass(RefTestString);
+
+export class RefTest extends Typegoose {
+  // ref objectid
+  @prop({ ref: RefTest })
+  public refField?: Ref<RefTest>;
+
+  @prop({ ref: 'RefTest' })
+  public refField2?: Ref<RefTest>;
+
+  // ref objectid array
+  @arrayProp({ itemsRef: RefTest })
+  public refArray?: Ref<RefTest>[];
+
+  @arrayProp({ itemsRef: 'RefTest' })
+  public refArray2?: Ref<RefTest>[];
+
+  // ref string
+  @prop({ ref: RefTestString, refType: mongoose.Schema.Types.String })
+  public refFieldString?: Ref<RefTestString, string>;
+
+  @prop({ ref: 'RefTestString', refType: mongoose.Schema.Types.String })
+  public refFieldString2?: Ref<RefTestString, string>;
+
+  // ref string array
+  @arrayProp({ itemsRef: RefTestString, itemsRefType: mongoose.Schema.Types.String })
+  public refArrayString?: Ref<RefTestString, string>[];
+
+  @arrayProp({ itemsRef: 'RefTestString', itemsRefType: mongoose.Schema.Types.String })
+  public refArrayString2?: Ref<RefTestString, string>[];
+
+  // ref number
+  @prop({ ref: RefTestNumber, refType: mongoose.Schema.Types.Number })
+  public refFieldNumber?: Ref<RefTestNumber, number>;
+
+  @prop({ ref: 'RefTestNumber', refType: mongoose.Schema.Types.Number })
+  public refFieldNumber2?: Ref<RefTestNumber, number>;
+
+  // ref number array
+  @arrayProp({ itemsRef: RefTestNumber, itemsRefType: mongoose.Schema.Types.Number })
+  public refArrayNumber?: Ref<RefTestNumber, number>[];
+
+  @arrayProp({ itemsRef: 'RefTestNumber', itemsRefType: mongoose.Schema.Types.Number })
+  public refArrayNumber2?: Ref<RefTestNumber, number>[];
+
+  // ref buffer
+  @prop({ ref: RefTestBuffer, refType: mongoose.Schema.Types.Buffer })
+  public refFieldBuffer?: Ref<RefTestBuffer, Buffer>;
+
+  @prop({ ref: 'RefTestBuffer', refType: mongoose.Schema.Types.Buffer })
+  public refFieldBuffer2?: Ref<RefTestBuffer, Buffer>;
+
+  // ref buffer array
+  @arrayProp({ itemsRef: RefTestBuffer, itemsRefType: mongoose.Schema.Types.Buffer })
+  public refArrayBuffer?: Ref<RefTestBuffer, Buffer>[];
+
+  @arrayProp({ itemsRef: 'RefTestBuffer', itemsRefType: mongoose.Schema.Types.Buffer })
+  public refArrayBuffer2?: Ref<RefTestBuffer, Buffer>[];
+}
+
+export const model = new RefTest().getModelForClass(RefTest);

--- a/test/tests/ref.test.ts
+++ b/test/tests/ref.test.ts
@@ -1,0 +1,210 @@
+import { expect } from 'chai';
+import * as mongoose from 'mongoose';
+
+import { isDocument, isDocumentArray } from '../../src/typeguards';
+import { model as RefTestModel, RefTestBufferModel, RefTestNumberModel, RefTestStringModel } from '../models/refTests';
+
+/**
+ * Function to pass into describe
+ * ->Important: you need to always bind this
+ * @example
+ * ```
+ * import { suite as RefTests } from './ref.test'
+ * ...
+ * describe('Ref Tests', RefTests.bind(this));
+ * ...
+ * ```
+ */
+export function suite() {
+  it('check generated ref schema for ObjectID _id', async () => {
+    expect((RefTestModel.schema.path('refField') as any).instance).to.equal('ObjectID');
+    expect((RefTestModel.schema.path('refField') as any).options.ref).to.equal('RefTest');
+    expect((RefTestModel.schema.path('refField2') as any).instance).to.equal('ObjectID');
+    expect((RefTestModel.schema.path('refField2') as any).options.ref).to.equal('RefTest');
+
+    expect((RefTestModel.schema.path('refArray') as any).instance).to.equal('Array');
+    expect((RefTestModel.schema.path('refArray') as any).caster.instance).to.equal('ObjectID');
+    expect((RefTestModel.schema.path('refArray') as any).caster.options.ref).to.equal('RefTest');
+    expect((RefTestModel.schema.path('refArray2') as any).instance).to.equal('Array');
+    expect((RefTestModel.schema.path('refArray2') as any).caster.instance).to.equal('ObjectID');
+    expect((RefTestModel.schema.path('refArray2') as any).caster.options.ref).to.equal('RefTest');
+  });
+
+  it('check generated ref schema for string _id', async () => {
+    expect((RefTestModel.schema.path('refFieldString') as any).instance).to.equal('String');
+    expect((RefTestModel.schema.path('refFieldString') as any).options.ref).to.equal('RefTestString');
+    expect((RefTestModel.schema.path('refFieldString2') as any).instance).to.equal('String');
+    expect((RefTestModel.schema.path('refFieldString2') as any).options.ref).to.equal('RefTestString');
+
+    expect((RefTestModel.schema.path('refArrayString') as any).instance).to.equal('Array');
+    expect((RefTestModel.schema.path('refArrayString') as any).caster.instance).to.equal('String');
+    expect((RefTestModel.schema.path('refArrayString') as any).caster.options.ref).to.equal('RefTestString');
+    expect((RefTestModel.schema.path('refArrayString2') as any).instance).to.equal('Array');
+    expect((RefTestModel.schema.path('refArrayString2') as any).caster.instance).to.equal('String');
+    expect((RefTestModel.schema.path('refArrayString2') as any).caster.options.ref).to.equal('RefTestString');
+  });
+
+  it('check generated ref schema for number _id', async () => {
+    expect((RefTestModel.schema.path('refFieldNumber') as any).instance).to.equal('Number');
+    expect((RefTestModel.schema.path('refFieldNumber') as any).options.ref).to.equal('RefTestNumber');
+    expect((RefTestModel.schema.path('refFieldNumber2') as any).instance).to.equal('Number');
+    expect((RefTestModel.schema.path('refFieldNumber2') as any).options.ref).to.equal('RefTestNumber');
+
+    expect((RefTestModel.schema.path('refArrayNumber') as any).instance).to.equal('Array');
+    expect((RefTestModel.schema.path('refArrayNumber') as any).caster.instance).to.equal('Number');
+    expect((RefTestModel.schema.path('refArrayNumber') as any).caster.options.ref).to.equal('RefTestNumber');
+    expect((RefTestModel.schema.path('refArrayNumber2') as any).instance).to.equal('Array');
+    expect((RefTestModel.schema.path('refArrayNumber2') as any).caster.instance).to.equal('Number');
+    expect((RefTestModel.schema.path('refArrayNumber2') as any).caster.options.ref).to.equal('RefTestNumber');
+  });
+
+  it('check generated ref schema for Buffer _id', async () => {
+    expect((RefTestModel.schema.path('refFieldBuffer') as any).instance).to.equal('Buffer');
+    expect((RefTestModel.schema.path('refFieldBuffer') as any).options.ref).to.equal('RefTestBuffer');
+    expect((RefTestModel.schema.path('refFieldBuffer2') as any).instance).to.equal('Buffer');
+    expect((RefTestModel.schema.path('refFieldBuffer2') as any).options.ref).to.equal('RefTestBuffer');
+
+    expect((RefTestModel.schema.path('refArrayBuffer') as any).instance).to.equal('Array');
+    expect((RefTestModel.schema.path('refArrayBuffer') as any).caster.instance).to.equal('Buffer');
+    expect((RefTestModel.schema.path('refArrayBuffer') as any).caster.options.ref).to.equal('RefTestBuffer');
+    expect((RefTestModel.schema.path('refArrayBuffer2') as any).instance).to.equal('Array');
+    expect((RefTestModel.schema.path('refArrayBuffer2') as any).caster.instance).to.equal('Buffer');
+    expect((RefTestModel.schema.path('refArrayBuffer2') as any).caster.options.ref).to.equal('RefTestBuffer');
+  });
+
+  it('check reference with string _id', async () => {
+    const id1 = 'testid1';
+    const id2 = 'testid2';
+
+    const refTypeTest = new RefTestModel();
+    refTypeTest.refFieldString = id1;
+    refTypeTest.refArrayString = [id1, id2];
+    refTypeTest.refFieldString = new RefTestStringModel();
+    refTypeTest.refArrayString = [new RefTestStringModel(), new RefTestStringModel()];
+
+    const { _id: _id1 } = await new RefTestStringModel({ _id: id1 }).save();
+    expect(_id1).to.equal(id1);
+    const { _id: _id2 } = await new RefTestStringModel({ _id: id2 }).save();
+    expect(_id2).to.equal(id2);
+
+    const { _id: refStringId } = await new RefTestModel({ refFieldString: _id1 }).save();
+    const { refFieldString } = await RefTestModel.findById(refStringId);
+    expect(refFieldString).to.equal(_id1);
+    const { _id: refArrayId } = await new RefTestModel({ refArrayString: [_id1, _id2] }).save();
+    const { refArrayString } = await RefTestModel.findById(refArrayId);
+    expect(refArrayString).to.deep.equal([_id1, _id2]);
+  });
+
+  it('check reference with number _id', async () => {
+    const id1 = 1234;
+    const id2 = 5678;
+
+    const refTypeTest = new RefTestModel();
+    refTypeTest.refFieldNumber = id1;
+    refTypeTest.refArrayNumber = [id1, id2];
+    refTypeTest.refFieldNumber = new RefTestNumberModel();
+    refTypeTest.refArrayNumber = [new RefTestNumberModel(), new RefTestNumberModel()];
+
+    const { _id: _id1 } = await new RefTestNumberModel({ _id: id1 }).save();
+    expect(_id1).to.equal(id1);
+    const { _id: _id2 } = await new RefTestNumberModel({ _id: id2 }).save();
+    expect(_id2).to.equal(id2);
+
+    const { _id: refNumberId } = await new RefTestModel({ refFieldNumber: _id1 }).save();
+    const { refFieldNumber } = await RefTestModel.findById(refNumberId);
+    expect(refFieldNumber).to.equal(_id1);
+    const { _id: refArrayId } = await new RefTestModel({ refArrayNumber: [_id1, _id2] }).save();
+    const { refArrayNumber } = await RefTestModel.findById(refArrayId);
+    expect(refArrayNumber).to.deep.equal([_id1, _id2]);
+  });
+
+
+  it('check reference with buffer _id', async () => {
+    const id1 = Buffer.from([1, 2, 3, 4]);
+    const id2 = Buffer.from([5, 6, 7, 8]);
+
+    const refTypeTest = new RefTestModel();
+    refTypeTest.refFieldBuffer = id1;
+    refTypeTest.refArrayBuffer = [id1, id2];
+    refTypeTest.refFieldBuffer = new RefTestBufferModel();
+    refTypeTest.refArrayBuffer = [new RefTestBufferModel(), new RefTestBufferModel()];
+
+    const { _id: _id1 } = await new RefTestBufferModel({ _id: id1 }).save();
+    expect(_id1.equals(id1)).to.equal(true);
+    const { _id: _id2 } = await new RefTestBufferModel({ _id: id2 }).save();
+    expect(_id2.equals(id2)).to.equal(true);
+
+    const { _id: refBufferId } = await new RefTestModel({ refFieldBuffer: _id1 }).save();
+    const { refFieldBuffer } = await RefTestModel.findById(refBufferId);
+    expect(_id1.equals(refFieldBuffer)).to.equal(true);
+    const { _id: refArrayId } = await new RefTestModel({ refArrayBuffer: [_id1, _id2] }).save();
+    const { refArrayBuffer } = await RefTestModel.findById(refArrayId);
+    expect(refArrayBuffer).to.deep.equal([_id1, _id2]);
+  });
+
+  it('check typeguards', async () => {
+    const idFields = await RefTestModel.create({
+      refField: mongoose.Types.ObjectId(),
+      refArray: [mongoose.Types.ObjectId()],
+      refFieldString: 'test1',
+      refArrayString: ['test1', 'test2'],
+      refFieldNumber: 1234,
+      refArrayNumber: [1234, 5678],
+      refFieldBuffer: Buffer.from([1, 2, 3, 4]),
+      refArrayBuffer: [Buffer.from([1, 2, 3, 4]), Buffer.from([5, 6, 7, 8])]
+    });
+
+    expect(isDocument(idFields.refField)).to.equal(false);
+    expect(isDocument(idFields.refFieldString)).to.equal(false);
+    expect(isDocument(idFields.refFieldNumber)).to.equal(false);
+    expect(isDocument(idFields.refFieldBuffer)).to.equal(false);
+
+    expect(isDocumentArray(idFields.refArray)).to.equal(false);
+    expect(isDocumentArray(idFields.refArrayString)).to.equal(false);
+    expect(isDocumentArray(idFields.refArrayNumber)).to.equal(false);
+    expect(isDocumentArray(idFields.refArrayBuffer)).to.equal(false);
+
+    const { _id: populatedId } = await RefTestModel.create({
+      refField: await RefTestModel.create({}),
+      refArray: [await RefTestModel.create({}), await RefTestModel.create({})],
+      refFieldString: await RefTestStringModel.create({ _id: 'atest1' }),
+      refArrayString: [
+        await RefTestStringModel.create({ _id: 'btest2' }),
+        await RefTestStringModel.create({ _id: 'ctest3' })
+      ],
+      refFieldNumber: await RefTestNumberModel.create({ _id: 12345 }),
+      refArrayNumber: [
+        await RefTestNumberModel.create({ _id: 56789 }),
+        await RefTestNumberModel.create({ _id: 98765 })
+      ],
+      refFieldBuffer: await RefTestBufferModel.create({ _id: Buffer.from([1, 2, 3, 4, 5]) }),
+      refArrayBuffer: [
+        await RefTestBufferModel.create({ _id: Buffer.from([5, 6, 7, 8, 9]) }),
+        await RefTestBufferModel.create({ _id: Buffer.from([9, 8, 7, 6, 5]) })
+      ]
+    });
+
+    const populate = Object.keys(RefTestModel.schema.obj);
+    const foundPopulated = await RefTestModel.findById(populatedId).populate(populate);
+
+    expect(foundPopulated.refArray).to.be.an('array');
+    expect(foundPopulated.refArrayString).to.be.an('array');
+    expect(foundPopulated.refArrayNumber).to.be.an('array');
+    expect(foundPopulated.refArrayBuffer).to.be.an('array');
+
+    expect(foundPopulated.refArray.length).to.equal(2);
+    expect(foundPopulated.refArrayString.length).to.equal(2);
+    expect(foundPopulated.refArrayNumber.length).to.equal(2);
+    expect(foundPopulated.refArrayBuffer.length).to.equal(2);
+
+    expect(isDocument(foundPopulated.refField)).to.equal(true);
+    expect(isDocument(foundPopulated.refFieldString)).to.equal(true);
+    expect(isDocument(foundPopulated.refFieldNumber)).to.equal(true);
+    expect(isDocument(foundPopulated.refFieldBuffer)).to.equal(true);
+
+    expect(isDocumentArray(foundPopulated.refArray)).to.equal(true);
+    expect(isDocumentArray(foundPopulated.refArrayString)).to.equal(true);
+    expect(isDocumentArray(foundPopulated.refArrayNumber)).to.equal(true);
+    expect(isDocumentArray(foundPopulated.refArrayBuffer)).to.equal(true);
+  });
+}


### PR DESCRIPTION
Merged changes from pr #149, solved conflicts, added itemsRefType (works the same as refType) to @arrayProps and tests