### PR TITLE
Fix the double typeguards

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -86,19 +86,3 @@ export function getClassForDocument(document: mongoose.Document): any {
   const modelName = (document.constructor as mongoose.Model<typeof document>).modelName;
   return constructors[modelName];
 }
-
-/**
- * Check if the given document is already populated
- * @param doc The Ref with uncertain type
- */
-export function isDocument<T>(doc: Ref<T>): doc is InstanceType<T> {
-  return doc instanceof mongoose.Model;
-}
-
-/**
- * Check if the given array is already populated
- * @param docs The Array of Refs with uncertain type
- */
-export function isDocumentArray<T>(docs: Ref<T>[]): docs is InstanceType<T>[] {
-  return Array.isArray(docs) && docs.every(v => isDocument(v));
-}


### PR DESCRIPTION
## Collection of what it does / fixes

- removes the typeguards from `utils.ts`, because there is an extra file for it named `typeguards.ts`

it got accidentally added in cf75bd0fc10b3d4909fd838c6c634b111229762c
