### PR TITLE
Deprecate szokodiakos/typegoose, use hasezoey/typegoose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+# This Repository got moved
+
+Please use [hasezoey's fork](https://github.com/hasezoey/typegoose) to be up-to-date
+Please dont create new issues & pull request anymore, thanks
+
+<br/>
+<br/>
+<br/>
+<br/>
+<br/>
+<br/>
+<br/>
+<br/>
+
 # Typegoose
 
 [![Build Status](https://travis-ci.org/szokodiakos/typegoose.svg?branch=master)](https://travis-ci.org/szokodiakos/typegoose)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typegoose",
-  "version": "5.8.1",
+  "version": "5.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -2,6 +2,7 @@
 import * as mongoose from 'mongoose';
 import 'reflect-metadata';
 
+import { deprecate } from 'util';
 import { constructors, hooks, methods, models, plugins, schema, virtuals } from './data';
 
 /* exports */
@@ -12,6 +13,8 @@ export * from './plugin';
 export * from '.';
 export * from './typeguards';
 export { getClassForDocument } from './utils';
+
+deprecate(() => undefined, 'This Package got moved, please use `@hasezoey/typegoose` | github:hasezoey/typegoose')();
 
 export type InstanceType<T> = T & mongoose.Document;
 export type ModelType<T> = mongoose.Model<InstanceType<T>> & T;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,6 @@
 import * as mongoose from 'mongoose';
 
 import { constructors, schema } from './data';
-import { Ref } from './prop';
-import { InstanceType } from './typegoose';
 
 /**
  * Returns true, if it includes the Type


### PR DESCRIPTION
as the title & branch says:

Add notes that the original repo (this one right here) got moved to a newer-version

@Ben305 merge this, when you are ready to "move" as by hasezoey#1
(this should be in the last published version of `typegoose`(npm))